### PR TITLE
Test clean patches

### DIFF
--- a/Baseline_code.ipynb
+++ b/Baseline_code.ipynb
@@ -24,7 +24,7 @@
         "colab_type": "text"
       },
       "source": [
-        "<a href=\"https://colab.research.google.com/github/MatchLab-Imperial/keras_triplet_descriptor/blob/read_modifications/Baseline_code.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
+        "<a href=\"https://colab.research.google.com/github/MatchLab-Imperial/keras_triplet_descriptor/blob/test_clean_patches/Baseline_code.ipynb\" target=\"_parent\"><img src=\"https://colab.research.google.com/assets/colab-badge.svg\" alt=\"Open In Colab\"/></a>"
       ]
     },
     {
@@ -38,11 +38,12 @@
         "\n",
         "This code introduces a two-step training for the N-HPatches problem. In N-HPatches problem, we aim to generate a patch descriptor that is able to perform successfully tasks such as matching, retrieval or verification. \n",
         "\n",
-        "Contrary to classical HPatches dataset, in N-HPatches, images contain random non-smooth perturbations produced by a synthetic noise. This noise could be critical when training the descriptor, therefore, we introduce a denoising model that could help us to deal with those perturbations. Denoising models have been already introduced in the course [tutorials](https://github.com/MatchLab-Imperial/deep-learning-course) and lectures, their objective is to generate a clean/denoised version of the input image. \n",
+        "Contrary to classical HPatches dataset, in N-HPatches, images contain random non-smooth perturbations produced by a synthetic noise. This noise could be critical when training the descriptor, therefore, we introduce a denoising model that could help us to deal with those perturbations. Denoising models have been already introduced in the course [tutorials](https://github.com/MatchLab-Imperial/deep-learning-course) and lectures, their objective is to generate a clean/denoised version of the input image.  We will refer in this code to the images with noise as `noisy`, to the images after applying the denoise model as `denoised` and the original patches from HPatches (so no extra noise added) which are used as ground-truth for the denoising step as `clean`. \n",
+        "\n",
         "\n",
         "Thus, we aim to minimize the noise in images before the second step, which is computing a feature vector, also called descriptor. Those descriptions must be a powerful representation of the input patches. The idea behind is that if two descriptors belong two similar patches, they should be close to each other, i.e. have a low Euclidean distance. See figure below:\n",
         "\n",
-        "![texto alternativo](https://i.ibb.co/4tvm3Vh/descriptorspace.png)\n",
+        "![](https://i.ibb.co/4tvm3Vh/descriptorspace.png)\n",
         "\n",
         "This baseline code gives a method you can use to compare to whatever another approach you develop.  There are several other approaches you can test to see if there is any improvement, e.g. train the descriptor directly with noisy patches, without the denoising model. However, this code provides some guidance about how to implement the different blocks, how to stack them if desired, how to read the data and how to evaluate the method.\n",
         "\n",
@@ -67,10 +68,10 @@
       "metadata": {
         "id": "ZZG4BqkENEyd",
         "colab_type": "code",
-        "outputId": "bee2c3ef-259e-48ed-8c45-cb73d428874c",
+        "outputId": "1dab350e-9179-4631-cae3-b9d43090e702",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 199
+          "height": 187
         }
       },
       "cell_type": "code",
@@ -94,7 +95,7 @@
         "  print(\"RAM Free: \" + humanize.naturalsize( psutil.virtual_memory().available ), \" | Proc size: \" + humanize.naturalsize( process.memory_info().rss))\n",
         "  print(\"GPU RAM Free: {0:.0f}MB | Used: {1:.0f}MB | Util {2:3.0f}% | Total {3:.0f}MB\".format(gpu.memoryFree, gpu.memoryUsed, gpu.memoryUtil*100, gpu.memoryTotal))"
       ],
-      "execution_count": 0,
+      "execution_count": 1,
       "outputs": [
         {
           "output_type": "stream",
@@ -118,22 +119,22 @@
       "metadata": {
         "id": "BBvIvBoyg68g",
         "colab_type": "code",
-        "outputId": "9bc30918-2926-4444-b67a-5669d291f2be",
+        "outputId": "bec85b71-f8d2-483b-9372-352868b5bbf9",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 54
+          "height": 51
         }
       },
       "cell_type": "code",
       "source": [
         "printm()"
       ],
-      "execution_count": 0,
+      "execution_count": 2,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "('RAM Free: 12.9 GB', ' | Proc size: 151.7 MB')\n",
+            "('RAM Free: 12.9 GB', ' | Proc size: 151.4 MB')\n",
             "GPU RAM Free: 11441MB | Used: 0MB | Util   0% | Total 11441MB\n"
           ],
           "name": "stdout"
@@ -158,10 +159,10 @@
       "metadata": {
         "id": "yV1m-9ZGuKGj",
         "colab_type": "code",
-        "outputId": "5f2b2b8f-57c0-47ef-be8a-2f9ef384d57e",
+        "outputId": "e97fb238-4869-42d3-e83a-4268d81e5eaf",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 163
+          "height": 153
         }
       },
       "cell_type": "code",
@@ -169,18 +170,18 @@
         "# Clone repo\n",
         "!git clone https://github.com/MatchLab-Imperial/keras_triplet_descriptor"
       ],
-      "execution_count": 0,
+      "execution_count": 3,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
             "Cloning into 'keras_triplet_descriptor'...\n",
-            "remote: Enumerating objects: 19, done.\u001b[K\n",
-            "remote: Counting objects: 100% (19/19), done.\u001b[K\n",
-            "remote: Compressing objects: 100% (13/13), done.\u001b[K\n",
-            "remote: Total 147 (delta 8), reused 16 (delta 6), pack-reused 128\u001b[K\n",
-            "Receiving objects: 100% (147/147), 149.76 MiB | 20.22 MiB/s, done.\n",
-            "Resolving deltas: 100% (41/41), done.\n",
+            "remote: Enumerating objects: 34, done.\u001b[K\n",
+            "remote: Counting objects: 100% (34/34), done.\u001b[K\n",
+            "remote: Compressing objects: 100% (24/24), done.\u001b[K\n",
+            "remote: Total 162 (delta 15), reused 22 (delta 10), pack-reused 128\u001b[K\n",
+            "Receiving objects: 100% (162/162), 149.81 MiB | 19.85 MiB/s, done.\n",
+            "Resolving deltas: 100% (48/48), done.\n",
             "Checking out files: 100% (69/69), done.\n"
           ],
           "name": "stdout"
@@ -191,10 +192,10 @@
       "metadata": {
         "id": "pyZSqhZ5LACT",
         "colab_type": "code",
-        "outputId": "6372f515-5a0c-45e5-9342-b132f44cdbaf",
+        "outputId": "d97dd58d-e75d-4151-f3d7-82dd56447476",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 35
+          "height": 34
         }
       },
       "cell_type": "code",
@@ -202,7 +203,7 @@
         "# Change directory\n",
         "%cd /content/keras_triplet_descriptor    \n"
       ],
-      "execution_count": 0,
+      "execution_count": 4,
       "outputs": [
         {
           "output_type": "stream",
@@ -217,10 +218,10 @@
       "metadata": {
         "id": "307CBCL-FjX4",
         "colab_type": "code",
-        "outputId": "ef727631-a916-4603-de41-7b19c601db52",
+        "outputId": "7fe3901b-992e-4545-a07f-3b4fa40cb77a",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 492
+          "height": 462
         }
       },
       "cell_type": "code",
@@ -228,35 +229,35 @@
         "# Download data\n",
         "!wget -O hpatches_data.zip https://imperialcollegelondon.box.com/shared/static/ah40eq7cxpwq4a6l4f62efzdyt8rm3ha.zip\n"
       ],
-      "execution_count": 0,
+      "execution_count": 5,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "--2019-02-15 11:37:41--  https://imperialcollegelondon.box.com/shared/static/ah40eq7cxpwq4a6l4f62efzdyt8rm3ha.zip\n",
-            "Resolving imperialcollegelondon.box.com (imperialcollegelondon.box.com)... 107.152.24.197, 107.152.25.197\n",
-            "Connecting to imperialcollegelondon.box.com (imperialcollegelondon.box.com)|107.152.24.197|:443... connected.\n",
+            "--2019-02-15 17:53:32--  https://imperialcollegelondon.box.com/shared/static/ah40eq7cxpwq4a6l4f62efzdyt8rm3ha.zip\n",
+            "Resolving imperialcollegelondon.box.com (imperialcollegelondon.box.com)... 185.235.236.197\n",
+            "Connecting to imperialcollegelondon.box.com (imperialcollegelondon.box.com)|185.235.236.197|:443... connected.\n",
             "HTTP request sent, awaiting response... 301 Moved Permanently\n",
             "Location: /public/static/ah40eq7cxpwq4a6l4f62efzdyt8rm3ha.zip [following]\n",
-            "--2019-02-15 11:37:41--  https://imperialcollegelondon.box.com/public/static/ah40eq7cxpwq4a6l4f62efzdyt8rm3ha.zip\n",
+            "--2019-02-15 17:53:33--  https://imperialcollegelondon.box.com/public/static/ah40eq7cxpwq4a6l4f62efzdyt8rm3ha.zip\n",
             "Reusing existing connection to imperialcollegelondon.box.com:443.\n",
             "HTTP request sent, awaiting response... 301 Moved Permanently\n",
             "Location: https://imperialcollegelondon.app.box.com/public/static/ah40eq7cxpwq4a6l4f62efzdyt8rm3ha.zip [following]\n",
-            "--2019-02-15 11:37:41--  https://imperialcollegelondon.app.box.com/public/static/ah40eq7cxpwq4a6l4f62efzdyt8rm3ha.zip\n",
-            "Resolving imperialcollegelondon.app.box.com (imperialcollegelondon.app.box.com)... 107.152.26.199\n",
-            "Connecting to imperialcollegelondon.app.box.com (imperialcollegelondon.app.box.com)|107.152.26.199|:443... connected.\n",
+            "--2019-02-15 17:53:33--  https://imperialcollegelondon.app.box.com/public/static/ah40eq7cxpwq4a6l4f62efzdyt8rm3ha.zip\n",
+            "Resolving imperialcollegelondon.app.box.com (imperialcollegelondon.app.box.com)... 185.235.236.199\n",
+            "Connecting to imperialcollegelondon.app.box.com (imperialcollegelondon.app.box.com)|185.235.236.199|:443... connected.\n",
             "HTTP request sent, awaiting response... 302 Found\n",
-            "Location: https://public.boxcloud.com/d/1/b1!Q0mfusrvXiRcwJll2xp4v4FE_AeM_jZMPDUUxxRshLifEzAq9Q8JSz0ZkQ4XBkNS9M9BUzCSePkKAHCNkwFnVyjim6yLDFVVuPU1iB7--7WGNPrL5huqNW_0bb48afsRT5mZn-lNj-4uPUn5OdjsSSKfj76uop_pg_QXR8i5ETHh2bB0Q78Xl8D_KZRWVd2qwpG4zMmlDGaxzS20qwwOCZ_qMHs44Ms-b1dxbNubYDsh7cNVCXh9cCMxkHx8hTI7vHtkD80q1kF8fTciovhY_bcIer3M7-PhrsUYSS3BC2Ky2YwaH-CoWKyO6zwHidUEY8RdX33q-4OWFd9Q-7knFiKnAyZwvaDaq7kM3jfK8WfT2tI7Zz1Tz8oxFdFmYe0smEjASLwVbbgGysUebUIFpXTgdK-UiBpLcZo1WZKlqazcDGtuijEBcNtooTPS2FyLXxP8_uC_JD_q8MB9FpJUXL9eBDwu72VJs2xxY6UpEQN4LW1dZ88yfksad-YeFnDYlGp2LTd6JJYDvyh2d1I6QdtNBxw_LPMNJ7ZzjDUwdkFaUn1AMYpi0-J9cNVH7QRhFknSyzYMvgktRIWmsWILGGtLbsPZB7DaDJF6LXZQKvm7-NvwHMdOzpSgSXCk5IaAzGrZurLrai49K9g8eCiSSTxaIAt_sNDBraNFY1CzB9iFvTOubkXUT4G5TrvbS397T_IodilpY3zsU4YlRC54TehSNjNXGhrrD6FeKbU3fMiN2M-I0XHUShwopj1AF9bsZziHDyUNiGYwpbqWB7I3aYnkIj879iwyC5Ty3gl5Sao34BEKI_rbUIU2au7xa1as1xdHmGZtUKnpwWGf5kJQs2wNCHuBJsyhHTJd1iUrxGz_8enOUfYxDa4JMe5DJVoSHEZugFscJZtrSIPjP4-lTDTo3HTDoj-op09jQxV-8pUW6cvJiB94JbmyShZEIwtX3QaYARvoSRaJslvhhsUwFOOhNwkb1QeKw0uP2MJIlFpiJMPjWl5XWIZEQtE6VPFuSeSM7KAcdCL3KO2M5YlRkuWr8y4KhjuNDHsnU7-Dm24xLhbX36rYtuob8vydB_F1hVNV_XbYTFmu2vN96TJEeFevQDGeHty207MU2X8fFtM4qi0P7Pd4QBMQuDV1lvbCpZf7MIALTAmMFVe04nnu5yjfPHaOhpPlgBj8aML2404xfa4MHknXZWtacAeD4cQpDk2h0UORPtqA4TBZ46qzKXC26Tubq7Cyz-qACAG4r4e63Dk_QvzMVCpqIJDV01scwDupSrom8EPZpvPr3L-_XlFaaQtnQLC5KjJxrvXKV5q43upwEpQHGHcgrHrPS6UXdRuRgHzCFZW2xsrQMZgcR5I2YtFTUU1UhvPLP4LAv-XW_vE5a4QFg1foyYEkKJ-61V5WVAd-q-kRWiSGWgD9gXdZsk3wytfpjd_lFETiPxp49wk./download [following]\n",
-            "--2019-02-15 11:37:42--  https://public.boxcloud.com/d/1/b1!Q0mfusrvXiRcwJll2xp4v4FE_AeM_jZMPDUUxxRshLifEzAq9Q8JSz0ZkQ4XBkNS9M9BUzCSePkKAHCNkwFnVyjim6yLDFVVuPU1iB7--7WGNPrL5huqNW_0bb48afsRT5mZn-lNj-4uPUn5OdjsSSKfj76uop_pg_QXR8i5ETHh2bB0Q78Xl8D_KZRWVd2qwpG4zMmlDGaxzS20qwwOCZ_qMHs44Ms-b1dxbNubYDsh7cNVCXh9cCMxkHx8hTI7vHtkD80q1kF8fTciovhY_bcIer3M7-PhrsUYSS3BC2Ky2YwaH-CoWKyO6zwHidUEY8RdX33q-4OWFd9Q-7knFiKnAyZwvaDaq7kM3jfK8WfT2tI7Zz1Tz8oxFdFmYe0smEjASLwVbbgGysUebUIFpXTgdK-UiBpLcZo1WZKlqazcDGtuijEBcNtooTPS2FyLXxP8_uC_JD_q8MB9FpJUXL9eBDwu72VJs2xxY6UpEQN4LW1dZ88yfksad-YeFnDYlGp2LTd6JJYDvyh2d1I6QdtNBxw_LPMNJ7ZzjDUwdkFaUn1AMYpi0-J9cNVH7QRhFknSyzYMvgktRIWmsWILGGtLbsPZB7DaDJF6LXZQKvm7-NvwHMdOzpSgSXCk5IaAzGrZurLrai49K9g8eCiSSTxaIAt_sNDBraNFY1CzB9iFvTOubkXUT4G5TrvbS397T_IodilpY3zsU4YlRC54TehSNjNXGhrrD6FeKbU3fMiN2M-I0XHUShwopj1AF9bsZziHDyUNiGYwpbqWB7I3aYnkIj879iwyC5Ty3gl5Sao34BEKI_rbUIU2au7xa1as1xdHmGZtUKnpwWGf5kJQs2wNCHuBJsyhHTJd1iUrxGz_8enOUfYxDa4JMe5DJVoSHEZugFscJZtrSIPjP4-lTDTo3HTDoj-op09jQxV-8pUW6cvJiB94JbmyShZEIwtX3QaYARvoSRaJslvhhsUwFOOhNwkb1QeKw0uP2MJIlFpiJMPjWl5XWIZEQtE6VPFuSeSM7KAcdCL3KO2M5YlRkuWr8y4KhjuNDHsnU7-Dm24xLhbX36rYtuob8vydB_F1hVNV_XbYTFmu2vN96TJEeFevQDGeHty207MU2X8fFtM4qi0P7Pd4QBMQuDV1lvbCpZf7MIALTAmMFVe04nnu5yjfPHaOhpPlgBj8aML2404xfa4MHknXZWtacAeD4cQpDk2h0UORPtqA4TBZ46qzKXC26Tubq7Cyz-qACAG4r4e63Dk_QvzMVCpqIJDV01scwDupSrom8EPZpvPr3L-_XlFaaQtnQLC5KjJxrvXKV5q43upwEpQHGHcgrHrPS6UXdRuRgHzCFZW2xsrQMZgcR5I2YtFTUU1UhvPLP4LAv-XW_vE5a4QFg1foyYEkKJ-61V5WVAd-q-kRWiSGWgD9gXdZsk3wytfpjd_lFETiPxp49wk./download\n",
-            "Resolving public.boxcloud.com (public.boxcloud.com)... 107.152.25.200, 107.152.24.200\n",
-            "Connecting to public.boxcloud.com (public.boxcloud.com)|107.152.25.200|:443... connected.\n",
+            "Location: https://public.boxcloud.com/d/1/b1!qIvxgrCJhvYo1tBTRI7ZmcgqH8WDb0Lem7Ro-ejdXdZSLhyNpg-cOFK2MpqZMSkqmCdJMgisWYNEUSQcJ_3VOjxU7rOWvoMf3zKviRd-UkA4D_naP_SjcMYsSe--SI0jwvCutRZkthVzt3KpCRQjDkzSj4wxhZdkozRpIBHaMYOrLJ2SGoDBxvKtKfyVnRahc_9ZxqX9gEgH1yAyTh93LPfFeQB2Ky5wLNukTYWctSEZTeA9Ra-d1mJ4yX5Sy9MyyliGcGDTIpiRBXwijD1xcqueyj3lf6cWYS7FcoCWtdf2pyt547mTHqEjQstVVAchjminPfwgIh5dOF9fvtpLgVGaGGOYLrsJg56vmaoeqf17c86hlI4vmL__WSSlPZ4iIyChfgtEnP0o52CnGvmozY5Y_P1tsBqmQGU6PsDAYKhpxVj3cN8-xcKtzMNIb9h4gvc2fCiUnWeWev2cHEgK5nSRrCgwIcVFExunncgug8wyo6WGYWqnDdccFr74FPnmkOjW-IZByV27i16nmEh3C--aghE-WKMaWsZzhoz2YQny0l0eH1Xm2ZD_6A9_qVT9uXJC1SipvTbeRTJ4MGxLL642phZ_sfxL3llYCmJn21Xitk23GbYTXf7j7R8ui1jDB2spIfV3CkmdJxnBCblshH4aqsSV3sAkDaQQQdwKVEGcRUZGW-UM-yc2niGWnDahakoRPVzl-syGAC3aHFFJrnLxLjlUtg5Ihh1d_ADZih5U-a2T5AxCAfi1K3VwapK_c8K1wfcc9tgiPTC8tfwf-UO44N1UgXloYFKpxCImdjfWpVdR_gnCPDrc0X2EPygxDqayloAnSfItrlSoouNAhPyLfkOe8bHHn-trhxOkfEDlFrHmHu_Uqz5zuBzhgbW5rVPlwADUKAKPJqwqbRooW5F3MQ3QvgdugmGQfQZW6yUPUmH_1YT_5o1lcev2bO9ST3NCDrzmGgspH-JXo9uu2PYzFtsUQgaVC8W_Ld8O2vfgjfIH57nG5qhQNlaHNJlGv11nQqDoz9cl9zoEUISZoARZJtEt436Ak45_kjwAwfqoRTa5FaR9JS43opAcSSQxKAwpJPeSErl230Yi7BckoyHmZe-wOXvYbcCAyJDOBwyFg6y9_NypqYflBn_--Ms-ZVgFR8ytfvzstMzlxDM6BtRU0qogL79w_63MiJlJ6BTRybfeN5trx5ip8GnSfcGojEIXmI7dGlyL1IAfdc_5kSFEXk9-vif3m0xchXtOeCWEnbydK-iSXiNEt93FFMy6muCVJXYGNOSwTpPwJgbt41EFWrn9SNM_y5Zc5S9wH98IxoLW0Qf6n1Y8XEBoSZpxxOE9v-1QY-z8zv8k2o-NSvM6Zg3pue3ri45Q_AR1iDxhtlY4pJmASYpbeJPxeruj80e_nvvC6kZnTha1T6bl23RRgbBBg0IS6punHRfd3b9Ts3rWvMc./download [following]\n",
+            "--2019-02-15 17:53:33--  https://public.boxcloud.com/d/1/b1!qIvxgrCJhvYo1tBTRI7ZmcgqH8WDb0Lem7Ro-ejdXdZSLhyNpg-cOFK2MpqZMSkqmCdJMgisWYNEUSQcJ_3VOjxU7rOWvoMf3zKviRd-UkA4D_naP_SjcMYsSe--SI0jwvCutRZkthVzt3KpCRQjDkzSj4wxhZdkozRpIBHaMYOrLJ2SGoDBxvKtKfyVnRahc_9ZxqX9gEgH1yAyTh93LPfFeQB2Ky5wLNukTYWctSEZTeA9Ra-d1mJ4yX5Sy9MyyliGcGDTIpiRBXwijD1xcqueyj3lf6cWYS7FcoCWtdf2pyt547mTHqEjQstVVAchjminPfwgIh5dOF9fvtpLgVGaGGOYLrsJg56vmaoeqf17c86hlI4vmL__WSSlPZ4iIyChfgtEnP0o52CnGvmozY5Y_P1tsBqmQGU6PsDAYKhpxVj3cN8-xcKtzMNIb9h4gvc2fCiUnWeWev2cHEgK5nSRrCgwIcVFExunncgug8wyo6WGYWqnDdccFr74FPnmkOjW-IZByV27i16nmEh3C--aghE-WKMaWsZzhoz2YQny0l0eH1Xm2ZD_6A9_qVT9uXJC1SipvTbeRTJ4MGxLL642phZ_sfxL3llYCmJn21Xitk23GbYTXf7j7R8ui1jDB2spIfV3CkmdJxnBCblshH4aqsSV3sAkDaQQQdwKVEGcRUZGW-UM-yc2niGWnDahakoRPVzl-syGAC3aHFFJrnLxLjlUtg5Ihh1d_ADZih5U-a2T5AxCAfi1K3VwapK_c8K1wfcc9tgiPTC8tfwf-UO44N1UgXloYFKpxCImdjfWpVdR_gnCPDrc0X2EPygxDqayloAnSfItrlSoouNAhPyLfkOe8bHHn-trhxOkfEDlFrHmHu_Uqz5zuBzhgbW5rVPlwADUKAKPJqwqbRooW5F3MQ3QvgdugmGQfQZW6yUPUmH_1YT_5o1lcev2bO9ST3NCDrzmGgspH-JXo9uu2PYzFtsUQgaVC8W_Ld8O2vfgjfIH57nG5qhQNlaHNJlGv11nQqDoz9cl9zoEUISZoARZJtEt436Ak45_kjwAwfqoRTa5FaR9JS43opAcSSQxKAwpJPeSErl230Yi7BckoyHmZe-wOXvYbcCAyJDOBwyFg6y9_NypqYflBn_--Ms-ZVgFR8ytfvzstMzlxDM6BtRU0qogL79w_63MiJlJ6BTRybfeN5trx5ip8GnSfcGojEIXmI7dGlyL1IAfdc_5kSFEXk9-vif3m0xchXtOeCWEnbydK-iSXiNEt93FFMy6muCVJXYGNOSwTpPwJgbt41EFWrn9SNM_y5Zc5S9wH98IxoLW0Qf6n1Y8XEBoSZpxxOE9v-1QY-z8zv8k2o-NSvM6Zg3pue3ri45Q_AR1iDxhtlY4pJmASYpbeJPxeruj80e_nvvC6kZnTha1T6bl23RRgbBBg0IS6punHRfd3b9Ts3rWvMc./download\n",
+            "Resolving public.boxcloud.com (public.boxcloud.com)... 185.235.236.200\n",
+            "Connecting to public.boxcloud.com (public.boxcloud.com)|185.235.236.200|:443... connected.\n",
             "HTTP request sent, awaiting response... 200 OK\n",
             "Length: 4088106554 (3.8G) [application/zip]\n",
             "Saving to: ‘hpatches_data.zip’\n",
             "\n",
-            "hpatches_data.zip   100%[===================>]   3.81G  20.8MB/s    in 3m 5s   \n",
+            "hpatches_data.zip   100%[===================>]   3.81G  21.0MB/s    in 3m 13s  \n",
             "\n",
-            "2019-02-15 11:40:47 (21.0 MB/s) - ‘hpatches_data.zip’ saved [4088106554/4088106554]\n",
+            "2019-02-15 17:56:47 (20.2 MB/s) - ‘hpatches_data.zip’ saved [4088106554/4088106554]\n",
             "\n"
           ],
           "name": "stdout"
@@ -294,10 +295,10 @@
       "metadata": {
         "id": "o0KYfe-at9KN",
         "colab_type": "code",
-        "outputId": "cdb2caca-5059-4ceb-95fc-92b2b827c990",
+        "outputId": "b9c623a5-354a-47fa-ada7-d7e22beafe23",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 35
+          "height": 34
         }
       },
       "cell_type": "code",
@@ -322,7 +323,7 @@
         "from read_data import HPatches, DataGeneratorDesc, hpatches_sequence_folder, DenoiseHPatches, tps\n",
         "from utils import generate_desc_csv, plot_denoise, plot_triplet"
       ],
-      "execution_count": 0,
+      "execution_count": 7,
       "outputs": [
         {
           "output_type": "stream",
@@ -551,10 +552,10 @@
       "metadata": {
         "id": "m_VPSHmSK0dS",
         "colab_type": "code",
-        "outputId": "4c0ae130-2710-43e6-a37d-5d17efaea0e5",
+        "outputId": "d4680eaf-3eb7-4758-cfab-6b6d683cd75e",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 54
+          "height": 51
         }
       },
       "cell_type": "code",
@@ -563,16 +564,16 @@
         "denoise_generator_val = DenoiseHPatches(random.sample(seqs_test, 1), batch_size=50)\n",
         "\n",
         "# Uncomment following lines for using all the data to train the denoising model\n",
-        "# denoise_generator = DenoiseHPatches(random.sample(seqs_train, 3), batch_size=50)\n",
-        "# denoise_generator_val = DenoiseHPatches(random.sample(seqs_test, 1), batch_size=50)"
+        "# denoise_generator = DenoiseHPatches(seqs_train, batch_size=50)\n",
+        "# denoise_generator_val = DenoiseHPatches(seqs_test, batch_size=50)"
       ],
-      "execution_count": 0,
+      "execution_count": 11,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "100%|██████████| 3/3 [00:03<00:00,  1.20s/it]\n",
-            "100%|██████████| 1/1 [00:00<00:00,  1.48it/s]\n"
+            "100%|██████████| 3/3 [00:03<00:00,  1.27s/it]\n",
+            "100%|██████████| 1/1 [00:00<00:00,  1.38it/s]\n"
           ],
           "name": "stderr"
         }
@@ -582,10 +583,10 @@
       "metadata": {
         "id": "-eUSba93Dttj",
         "colab_type": "code",
-        "outputId": "e911fa31-5a3c-48b0-9ab5-0a2ffa0fec9d",
+        "outputId": "3c7a8e9b-876d-4768-bc33-9a074dd42ffc",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 92
+          "height": 88
         }
       },
       "cell_type": "code",
@@ -593,7 +594,7 @@
         "shape = (32, 32, 1)\n",
         "denoise_model = get_denoise_model(shape)"
       ],
-      "execution_count": 0,
+      "execution_count": 12,
       "outputs": [
         {
           "output_type": "stream",
@@ -620,10 +621,10 @@
       "metadata": {
         "id": "edwbgE6yKqcD",
         "colab_type": "code",
-        "outputId": "e57d3336-67e9-46e7-ffd8-449479c6e41e",
+        "outputId": "8dd274f2-0c14-4124-a36b-d904d050ead3",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 146
+          "height": 139
         }
       },
       "cell_type": "code",
@@ -643,7 +644,7 @@
         "  ### Uploads files to external hosting\n",
         "  !curl -F \"file=@denoise.h5\" https://file.io\n"
       ],
-      "execution_count": 0,
+      "execution_count": 13,
       "outputs": [
         {
           "output_type": "stream",
@@ -652,8 +653,8 @@
             "Instructions for updating:\n",
             "Use tf.cast instead.\n",
             "Epoch 1/1\n",
-            "1797/1797 [==============================] - 48s 27ms/step - loss: 11.4135 - mean_absolute_error: 11.4135 - val_loss: 7.5952 - val_mean_absolute_error: 7.5952\n",
-            "{\"success\":true,\"key\":\"oTdoaV\",\"link\":\"https://file.io/oTdoaV\",\"expiry\":\"14 days\"}"
+            "1797/1797 [==============================] - 50s 28ms/step - loss: 11.4135 - mean_absolute_error: 11.4135 - val_loss: 7.6019 - val_mean_absolute_error: 7.6019\n",
+            "{\"success\":true,\"key\":\"Hh7YWI\",\"link\":\"https://file.io/Hh7YWI\",\"expiry\":\"14 days\"}"
           ],
           "name": "stdout"
         }
@@ -734,29 +735,29 @@
       "metadata": {
         "id": "XFA_8uN4Eb3B",
         "colab_type": "code",
-        "outputId": "649cd1c0-37f7-4650-8676-174efc31fb6e",
+        "outputId": "9b0d86ca-15c3-428d-80a4-930609c4b7b6",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 202
+          "height": 200
         }
       },
       "cell_type": "code",
       "source": [
         "plot_denoise(denoise_model)"
       ],
-      "execution_count": 0,
+      "execution_count": 15,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
-            "100%|██████████| 1/1 [00:00<00:00,  1.59it/s]\n"
+            "100%|██████████| 1/1 [00:00<00:00,  1.56it/s]\n"
           ],
           "name": "stderr"
         },
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcwAAACmCAYAAABXw78OAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJztnXm8TtX+xz+GJEOmkpIh8hzzeMjM\nOaZQGSKVqS6XE81uofqVRHVxb5mKxmtskKFUlOngGE5JijKmOKQBB0VE9u8Pr+fcsz57nWfth+Oc\ncj/v16s/Ps5+9l577bWf1bM+6/v95vA8z4MQQgghIpIzuxsghBBC/BXQhCmEEEIEQBOmEEIIEQBN\nmEIIIUQANGEKIYQQAdCEKYQQQgRAE2YA9uzZg5iYGAwZMiS7myIE4uPjER8fn23XnzNnDmJiYjBn\nzpxsa4MITnJyMmJiYjB+/PjsbspfntzZ3YDMYM6cORg6dCguvvhifPDBByhVqpT1uPj4eJQsWRLT\npk2L6vzFihXD2LFjUbJkycxorvgTEB4z6bnoootQuHBhxMTEoFmzZujcuTMKFCiQTS3MmCeeeCK7\nmyCyEc/zsGDBArz33nvYtGkTDh06hIIFC+LKK69EfHw8unbtiiuuuCK7m3lBckFMmGFOnDiBp556\nCi+99FKmnveSSy7B9ddfn6nnFH8ObrzxRrRs2RIAcPLkSfz4449Ys2YNnn76abz00ksYPXo0GjRo\nkM2tNGnWrFl2N0FkE4cPH8Y999yD5ORkVK5cGb169UKJEiVw4MABJCcnY8KECZg2bRrGjh2L+vXr\nZ3dzLzguqAnzuuuuw/Lly/Hxxx+jdevW2d0c8RcgFAr5/meob9+++OKLLzBw4EAkJCRg5syZqFKl\nSja1UIgzeJ6HBx98EMnJyXjggQfQv39/5MiRI+3vd955J1auXIm7774b9957LxYsWIBixYplY4sv\nPC4oD/Pvf/87ypQpg5EjR+LYsWPO40+fPo2pU6eiY8eOqFGjBmrUqIGbbroJr776Kk6dOpV2nM3D\nPHnyJP7zn/+gY8eOiI2NRa1atdCuXTuMGzcOv//+OwDgvvvuQ0xMDDZt2uS79u+//47Y2Fi0aNEC\nyk7456NGjRoYO3Ysjh8/jpEjRxp/e+edd9ClSxfUqFEDtWrVQqdOnTBt2jScPn067ZjwmHn00Uex\nfft29O3bF7GxsahevTq6d+9uHRMrVqxA7969ERsbi6pVqyI+Ph4jRozAwYMHjeNsHubixYvRs2dP\nNGzYENWqVUNcXBwee+wxfP/9977rBGk/ABw7dgwjRoxA48aNUa1aNdxwww3yLbORxMREJCUloXXr\n1khISDAmyzBNmjTBgw8+iLZt2+LXX3+NeL49e/Zg6NChaNy4MapWrYpGjRph0KBB+Oabb3zHfvnl\nl7j33ntRv359VK1aFXFxcbjvvvuwc+dO47iwv/3uu+9iyZIl6Ny5M2rUqIG6devi/vvv943lvxoX\n1C/MPHny4P/+7//Qt29fjB8/HoMHD454/GOPPYbZs2ejSZMm6Nq1K3LlyoXly5dj1KhR2Lx5M8aM\nGZPhZ0eMGIE333wT7du3R8+ePZErVy58+umneOGFF7Bt2zZMmDABXbp0wcKFCzF37lxUrVrV+PzK\nlSvxyy+/4I477rAOfJH91KlTB3Xr1sWnn36KlJQUlCpVCs8++yxef/11tGjRAt26dcOpU6ewbNky\njBgxAlu2bPFNrj/99BPuvPNOtG/fHu3bt8e2bdswdepUJCQkYOnSpciTJw8AYO7cuRg6dCjKlSuH\nhIQEFC1aFF999RXeeOMNJCUlYc6cOciXL5+1nR9++CEeeOAB1KhRA3fffTcKFiyInTt3YurUqUhK\nSsIHH3yA/PnzA0BU7X/44YexaNEitGjRAnFxcTh8+DBefvll+WPZxLx58wCc+SUZid69ezvPlZKS\ngq5duyJ37ty49dZbcfXVV2P37t2YMWMGEhMT8eabb6JChQoAgM2bN6Nnz54oUqQI+vfvj8suuwy7\ndu3C1KlTsWrVKsyfPx9XXnmlcf6VK1di7dq16NGjB4oXL47ExEQsWLAAJ0+exMSJE8+yB/4EeBcA\ns2fP9kKhkLd27VrP8zzvnnvu8SpXruxt3brVOC4uLs7r0aOH53met2HDBi8UCnl/+9vfvNOnTxvH\n9evXzwuFQt6GDRs8z/O8lJQULxQKeYMHD047pnbt2l779u19bZk8ebI3cOBA7+jRo94ff/zhNW/e\n3KtXr5534sQJ47hBgwZ5MTExXkpKyrl3gIia8JiZPHlyxOPGjRvnhUIhb/78+d7mzZu9UCjkDRs2\nzHfcPffc44VCIe+rr77yPO+/YyYUCnkffvihcezQoUO9UCjkrV692vM8z/vtt9+8unXreg0aNPAO\nHz5sHPvyyy/72hkXF+fFxcWl6YSEBC8UCnkHDhwwPrtixQqvT58+3saNGz3P86Jqf/jY7t27G+/H\nwYMHvfr163uhUMibPXt2xL4TmUvz5s296tWreydPnozqc2vXrvVCoZA3bty4tH8bOHCgV6tWLW/X\nrl3GsZs3b/YqVarkJSQkpP3bvHnzvB49enjJycnGsW+88YYXCoW8iRMnpv1b+L2qXr26t2fPnrR/\nP336tNeqVSuvcuXKvu/CvxIX1JJsmEceeQR58uTBk08+meFy56JFiwAAt956q+8XXufOnQEAy5Yt\ny/AauXPnxo8//og9e/YY/96vXz9MmDAB+fLlQ86cOdG5c2ccOnTIONfvv/+OpUuXol69erj66qvP\n6h5F1nD55ZcDAA4cOIAFCxYAANq1a4cjR44Y/7Vp0wYA8MknnxifL1GiBNq2bWv8W7Vq1QAAP//8\nc9pnDh8+jHbt2uHSSy81jg2PxcTExAzbmDv3mYWi9evXG//epEkTvPLKK2mrG9G0f+3atWnHpn8/\nihQpog1w2cT+/ftRrFixtOd9tvz2229ITExEnTp1ULhwYWMcXHXVVahQoYIxjjt06IBp06ahXr16\nAIBff/0VR44cSYsa2Lt3r+8arVu3NqIKcuTIgSpVquDUqVNITU09p/ZnJxfUkmyYEiVK4O6778ao\nUaMwd+7ctC+d9ITX3sPLDum55pprAADfffddhtcYOHAgRo4cibZt26Jp06Zo2LAhGjdujDJlyhjH\nde7cGS+88ALmzp2b9qW0YsUKHD161Nou8eci7GXnzp0bO3bsAAD06NEjw+PZMyxdurTvmIsvvtg4\nd3gshkIh37FFixZF4cKFI47FPn36pG32qF27Npo0aYKGDRuievXqxmQXTftTUlIAAGXLlvUdU758\n+Qw/L84fOXPmzJT9Drt27cLJkyexYsUK1K1bN8PjfvnlFxQsWBCe52HmzJl4++238e233+LEiRPG\ncX/88Yfvs5HG/cmTJ8/xDrKPC3LCBM6s48+dOxejR49GixYtUKhQIePv4U1Bl1xyie+zefPmBXDm\n/8QyolevXihfvjymTp2KlStXYvHixQCA2rVrY9iwYYiJiQEAlCxZEg0bNsTKlSuxf/9+XHbZZViw\nYAHy58+fNoGKPy/hFYTixYvj6NGjAIB///vfuOyyy6zHh3+Rhgl7lJGINBaBM+PxyJEjGX6+Zs2a\nmD17Nl577TUsXrwYn332GZ5//nlcffXVGDx4cNqO8WjaHx774XchPeEvPpG1FC9eHPv27cPvv/8e\naFxlRHgzUOPGjdGvX78Mjws/57Fjx+LFF19E+fLlMXjwYJQuXRp58uTBjh07MHz48IifvdC4YCfM\n3Llz44knnkCPHj3wr3/9y/dgwxsobLtpw/8W3iiREY0aNUKjRo1w/PhxfPLJJ3j//ffx3nvvoXfv\n3vj444/TltduvvlmJCUlYeHChbj55puxdOlStGvXLsMvSPHnISkpCTly5ECdOnXSNl2UKlUK1atX\nz7RrRBqLwJnJyzUWy5cvj5EjR+Kpp57Cpk2bsGjRIsyYMQP33nsvpk+fjtjY2LRzBGl/eKLkXxOR\n2inOL7Vq1cLu3bvxySefoHHjxhGPTU1NRZEiRax/CyfjyJkzJ6677rqI5zl16hSmTp2KQoUKYfr0\n6ShatGja38LRAP9LXJAeZpi6deuiY8eOmDVrFr788kvjb9deey0AYNu2bb7PhbdVlytXLtB18ubN\ni6ZNm2LUqFHo3bs3UlNTDQ+gZcuWKFy4MD788EMsW7YMx44dQ6dOnc72tkQWsWjRImzfvh2tWrVC\n0aJF08YMe4XAmV9vtsklCJHG4s8//4zDhw8HHos5c+ZE9erVMWjQIIwePRqe5+Hjjz82rhOk/Vdd\ndRUA+Dx6ANi+fXugtojMJfydMWnSpIhLs7Nnz0Z8fHzaPg2mbNmyuOiii7Bx40br8mj60I/U1FQc\nPXoUMTExxmQJAOvWrTub2/hLc0FPmMCZrfEFChTAE088Yay1h5dD33rrLWPweZ6Ht99+GwAyTH6w\nadMmtGnTJu249IT/7y39kkmePHnQoUMHrF+/HlOmTEHZsmURGxt77jcnzhvr1q3Do48+iksvvRQP\nPfQQAKRt3nnjjTdw/Phx4/jRo0ejfv362L17d9TXqlevHooWLYoPP/wQhw8fNv721ltvAUCGy/fH\njx/HLbfcYg2h4rEYTfvDGzwWLlxoHHfw4MEMv4jF+aVBgwZo2bIlPv30UwwfPtw62S1fvhzDhw9H\nvnz5MvyOyZs3L5o3b47U1NS0VZMwKSkpiI+PT0u/WLhwYeTKlQv79u0zvie3bt2K9957DwB8Y+lC\n5oJdkg1TrFgx3H///WlLsmEzukqVKrj99tsxc+ZMJCQkID4+HqdOncLSpUuxdu1a3HnnndZNGABQ\nsWJFXHzxxRg+fDi2bNmCqlWrIleuXNiyZQumT5+OChUq+NJSdenSBVOmTMGGDRtw//33n9+bFoHZ\ntm1b2qTgeR4OHDiAVatWYdmyZShWrBjGjx+fNmYqVqyI3r17Y8qUKbjtttvQrVs35M6dOy271E03\n3WTd7OAiHD/84IMPonv37ujSpQsKFiyIL774ArNmzULNmjXRtWtX62fz5s2LKlWqYObMmThy5Aia\nN2+O/PnzY+/evZg5cyby5cuXtrksmvZXr14dDRo0QFJSEu677z40btwYhw8fxjvvvIOaNWtG3LUr\nzh+jRo3Cgw8+iJkzZ2L16tW48cYbUbp0aRw8eBBr1qxBYmIiSpcujUmTJmW4JAuc+SGxbt06PPnk\nk9i5cycqVaqEvXv3YsaMGciRIwe6desG4Ex+5VatWmHhwoX4xz/+gaZNm2LXrl2YOXMmxowZg/79\n+2PNmjWYM2dOthYEyCou+AkTAG677TbMmTPHl13l8ccfR/ny5fH2229j5MiRyJkzJ6699lqMGDEi\nwy8o4Iw/OmPGDLz44otYsmQJ5s6di5MnT6JkyZLo3r07EhISfKZ8KBRClSpVsHnzZnTs2PG83KeI\nnvnz52P+/PlpukCBAihXrhzuu+8+dO/e3Rfm8cgjj6BChQp466238Mwzz+D06dMoW7YsHnroIdxx\nxx1n3Y527dqhUKFCmDx5clq2qJIlS6Jfv37o379/xE0ejz/+OMqVK4d58+ZhzJgxOHbsGIoWLYp6\n9erhrrvuMpZzo2n/uHHjMHr0aCxevBhLlixBmTJl0KdPH1x++eWaMLOJ/PnzY/LkyVi0aBHmzZuH\nN998E4cOHUKePHlQoUIFDBs2DB07dnTujyhdujRmzZqFiRMnYv78+Zg6dSoKFiyIevXqYcCAAahY\nsWLascOGDUOePHmwatUqJCYmokqVKpgwYQJiY2MxYMAAvPrqqxg9ejTq1Klzvm8/28nhZcY+ZeHk\n6NGjiI+PR2xs7F8704UQQvyPcsF7mH8WXnzxRRw6dAh9+vTJ7qYIIYQ4C/4nlmSzi/379yM5ORmr\nV69OS3hdu3bt7G6WEEKIs0BLsueRzz77DD169ECBAgXQoUMHPPzww+cUcCyEECL70IQphBBCBEAe\nphBCCBGAiB7mXXfdZWguMMsJobkq/Q8//OA7J9fSS799GfhvoHaYnDnNOT1c6SEMZ5vg89nawAnS\neZk0ffFo4Extt/TUqlXL0OEMKmEqV65saFs+zuLFixv6s88+i3jOVatW+c4R6Zp8flsaKw6y5wBk\nrr/Yq1eviG3ILAoXLmxorrXH29d5XNryrnLl+RIlShg6nGc1zMaNGw3N2/Q3bNhgaA4StyUt54K+\nXEyX28jPg+PqKlWqZGguJMDvI/DfZAZhfvzxR0Nz2jvup19++cXQ3G98/iAWBPcDZ0xq0KCB8xzn\nSjizURhOCuBKA2dLQO6C+yZXrlyGvuiiiyIez3+35W91ncN1Tv7u4neTv0tt475UqVKG5gpN/G7x\n+8vjg//OOb85I5HtmjxO+d3MKHWkfmEKIYQQAdCEKYQQQgQg4pIsL2fyUgkvjR04cMDQnPAcgC/L\nfrjuXpgBAwYYevny5Ybm8km8dMLFVZ977jlfG4YMGWJoXo5huAAwL9fxkgMnp+ZlLcC/3Ll//35D\nf/vtt4a+/fbbDc1LZ9z3vMRrawO3m5c2zmaZKTPgJW9eguF75XHJy4yA/xnzUhQvf6Yvfgv4l315\n+ZP7yrYsxNfgNHq87MeFzRl+Xvv27TO0rTg5X4PtB14e47/zkhxnQuJnYyt2XLBgQUOz7ZId446f\nr6sN/Hfb8bzEytqFa4mWv0O4H4Nc0zUeuF9Yu747AX+7eTmUxxD/nUvRcb5ltgVsNgD/29mOMf3C\nFEIIIQKgCVMIIYQIgCZMIYQQIgARPUxeG+b18C1bthg6NTXV0LaKH7z+zGvoM2fONDRvleb1bF5D\n//rrrw197733+trA6em4DexfcWUGPme4LlwY9mhsISG8jZnDYdgD++qrrwzN/RAueh2Gn5XNw2SP\nme87u+Bt5Ax76xzqYLtX9ma4/9ln4THBIR881tlLtxVZ5nHBHqXLL2LNYUG8H8DWjzExMYbm8CMO\nE+CwAn4f2XvnccshQYB/3HHfRypLdb7g7yXmfISNROtpct/bwtUY9jVdXi1rHtf8d36PbOE3rhAd\nPiffV/78+Q3Nniefz1afk6/Bn+F+yQj9whRCCCECoAlTCCGECIAmTCGEECIAET1M9hLYJ+OYykOH\nDhl6+vTpvnM+8sgjhmY/ilO88doyx9g1bNjQ0OxhLlmyxNeGnj17GnrSpEmGZr+KfZ5ly5YZmv0P\njh3ldX7AnyKQNccisd9RqFAhQ9esWdPQ7ANwvwD+vt68ebOhuW+zCo4F5P51eTc2P4r9H1c6No4f\nZM+D28iepi0WlD1LjptkeEzwu8JxmDxuOU4P8KdcZF+VazGw/8TnZL+YvaJdu3b52sBjl2M7XfGn\n5wNX6jsXQfxIVyxgtPpc22zD5VkyvM+FNeAfp+wx8jVd6ftc6RY5Rt3WriBxtDb0C1MIIYQIgCZM\nIYQQIgCaMIUQQogARPQwOW8r+z4cB8bYYlu++OILQ7MfyOvPnA+TyyhxOTDOb2srDbRw4UJD831x\nXBh7Llzui/3BRx991NA2H6du3bqG5vves2ePob///ntDc7wcxyaxp8b3AAB79+419M8//2xoW27K\nrID9BvYT2UfjvrF5GFyOi+My2bsLhUKGZp+FfdKffvrJ0LZYUH5f+D75mhxfynlaec8A+2jsUQP+\nvuP75neBxwBfg/c5sP/I/Qz43wf2MDmW0zZ2M5ugcXjRfD7aOEvXOdmzDFI6zQV7d+zl87jne+L3\nwObd8xjh7yqGPU8+nseDK1YY8Pely9PMCP3CFEIIIQKgCVMIIYQIgCZMIYQQIgCaMIUQQogARNz0\nY9s8kR5XAnDemAL4N8g0a9bM0GvWrDG0q8gxbwqaN2+eoTt16uRrAyfGrlatWsQ2cSKCuLg4Q/MG\nHTa+bRsC2MDn5OqccJjN9o8++sjQbdq0ifh53kAC+Deh9O7d29ATJkwwNCdHOF/wJhDeOMIbUTiJ\ngM3A5+QRvJGInxFvfuGNKJxEIEhwNT+Ta665xtC8yY7bzJuyeLMDa9u443OydiUN4L9zP/LfbRvH\neBMHH8MFw7MC3ujHm13OhmiD4/kd5+P5u4/hZCdA9PfFf+fNMfy9xWOa30XA/7xZ8zjlc3IbeHzw\nfdv6mdvN57All7GhX5hCCCFEADRhCiGEEAHQhCmEEEIEIKKHyT4Ne3vJycmGbtKkiaFtCb/Z29m6\ndauhy5Yta2j2jlwJrNnL40BcALj55psNzYHUvA7PHicnKec2coJrLuwL+BMucEJ4DrTnvmUPk/0N\nThBhS1h+/fXXG3rFihWG5iQRWQX7LpwgnD1NDoy2+RHs/3GxbPbK2Rfh/uPE6DxmbIWTOaCaz8H3\nyX4Se3089vn8Ns+Lkx/wNfn95PeN28R+E+974IQOgL+v+TMur+58wPft8vr4Wdg8ax4TruTrjKvg\nNLeB35uM/i0SrgLRTJDkDDxG+N1ij9J1PL+Lrn62tdOVED4j9AtTCCGECIAmTCGEECIAmjCFEEKI\nAET0MHldl/1A/jt7nuz9AcCqVasMzf4fe0vssXDsJ3tTMTExhuYYScDv73GhZC463bx584jX4PhE\n9pY4pg8AGjVqZGiOPeQ1d0607fImONaUzw/44584DtCVXP98wR4Fe17r1683NMcCcmwu4PfJ+F65\n+DJ7d+yz8Oc5ITSfD/B7LRyPxr4ZP7NKlSoZmu+Tk9DzmLH9G3tWtgLA6eFk2+wFcbxvkHHH7wv7\nZrVr147YpsyA3zfX+8XH2+IPXV6bK07TFdvLXh9/lwL+d8MWj50eWyxnJFzF3AF/zCPHqfMY4vvi\n+3b1PX8e8N+XK+Y1I/QLUwghhAiAJkwhhBAiAJowhRBCiABE9DDZu9u5c6ehXR6KLSdkixYtDM2e\nJfuiHI/IniTHIrlieAB/rObEiRMN3bp1a0NzzCN7SezVvvLKK4b+9ttvfW3gdXfuB46BfPvttw3N\neXo5hy7fty0ukOMwV69ebWiOkc0q2MvjPLtMkFgw9kFLly5taI5h/O677wzNHgd76+zVcSwu4PcH\n9+/fn3GD4Y4NZA+UYx5tfhV7mLwHgO+Lj+ecnOxHsXfLew4A/32wD8aFzbMCVzFmHmN8vC1nrusY\nV3FuxlaM29UGHtfsH/M5eRyzZk+Uv8dsnqbLu3UVxmbN5wsSa8rXOFv0C1MIIYQIgCZMIYQQIgCa\nMIUQQogARBWHuWXLFkPny5fP0OwL2XwB9kQ4nyb7oK4cf+yzcoxeuXLlfJ/hYz7//HNDV6lSxdC9\nevUyNNeJZO+A4zJtcUHsWU6ZMsXQ7dq1M7Sr9iHn9eXalrY4sZUrVxqac//WrVvX95msgOM/OS6P\nPQv2Z239zXDsF/uL7P9xG9jr47hNWwwk+0Xs/7EXzs+Y28Rx0RyHZ2sD55Ldtm2boTm+lOH7ZN+N\nvxPY8wLccXgc65kVuDxKJkjcHvtmrjhL1zW4n1x+IuDOect5mPmcLj+Rx6jrngC3h8nvCZ+T5wxu\ngy0PMF/D9WwyQr8whRBCiABowhRCCCECoAlTCCGECEBED3PWrFmGbty4saE//vhjQ3MMlq0WJfsT\nvMbO6/AcW8ZeEseCsudpy4fK5+C4ysqVKxuaY+r4HtjX4eM59gkAli9fbmj2dbjd3CaOkezfv7+h\neV3f9ix4rZ/jbNmnyyq++eYbQ7O/wM+c88Ta+pu9OfYsOWaYY2e5DRwDyb6qzUfhc3CMG+8BSE1N\nNTSPET6ez2fLYcxxlzwuPM8zNPuifJ/cr/z+8j0A/r7ndzbaGo5ZgcvzCuKBRRvr6dLs9dliDblv\n+XuBPWf2//l5cnw3vwc2+PuW30++BseORttvrlqmgP95qR6mEEIIkYlowhRCCCECoAlTCCGECEBE\nD5NzXXLMVocOHQzNMY9vvfWW75zsF3IsYLdu3QzNftaoUaMM/dprrxm6SZMmhmZ/EQAqVKhgaPbq\nOHcpr4lzHFCdOnUMzf6kzceJj483NNcJLV68uKE5VpRjQ9etW2foli1bGvqFF17wtYF90fbt2xs6\naGxSZsPPjOMs2TdhD8QW+8eeJD8T9knYF+UxwJ4n+0nsLwL+vKrs1bA3zm1m35q9XD5f2bJlfW1g\nD4vvg/uW63y6ajJyXJ8tLyx7mK68vFkB+2zR1ksMks842tg/Vw5V9gJtHiafgz9j8/vTw/flime0\n9QO3gT/DnjWPUZenfTZ5YvkzHOOaEfqFKYQQQgRAE6YQQggRAE2YQgghRAAiepjdu3c3NNeiXLp0\nqaHZF2KfDvDncWX/IiUlxdCcz/T+++83NMcfPvfcc4bmmo+A3/vhHJ4cm/biiy8amuMVO3XqZOhQ\nKGToqlWr+trANTbZf+J1fK4jOn36dENzTl1+VuzRAO54Rlsdz6yAPUuODeScquwN2jwPzqHKeVbZ\nu3Pl1OQxwF6ezYfjmEYe+7t27TI014Ll58PPlPuN46IBf99wv3A/sJfu8nrYE+U2287BsYD8LmQF\n5+rX22IF+d9cuWGDnDMSNj+SvTqXD8ptZO+e28yeZZAYWm4D++Tsg/PxQfxixpUrOEjsJqBfmEII\nIUQgNGEKIYQQAdCEKYQQQgRAE6YQQggRgIibfpKSkgzNm3ratm0b8XhbYl7e1MOGLycy6NOnj6F5\ngwdvjODCy7ak41y8mZPIc5L5999/39CPPfaYoVesWGFo3uSzePFiXxt4IwtvdOCNEGy2ly9f3tC8\nYYQ3hHCyBgBYs2aNofnZ9O3b1/eZrIBNf06MzBtReAzxfdjOwf3DyRJ4QxQnnebPczC+bZMVbyzg\nNvFGJB673AbeUPPDDz8YmpMpAO4E8K7kCrzhir8TeLOaLXEBfy/wfWbHpp9z3Vhi2+zi2vTj0q7k\n60yQjUtc7II3t7muEW2CeMCdgIG1q2g13wPj+rvtnEHRL0whhBAiAJowhRBCiABowhRCCCECENHD\n5OTqvN7NHskdd9xhaFsw6OrVqw3tSvbMPg8HiHNiA04IMGbMGF8b2LPkIP8SJUoYukGDBoZmX4a9\npWeffdbQnDAeAL788ktD831xwDEnhL/uuusMzf3KPiAXDgb8XisXA7YlMc8KOOCe/QYO+Od2sj8M\n+O+Nnxn7HnwN7k/+PHugpUpbC0K/AAASBUlEQVSV8rWBk6uz78neLPcDJ3Rnv3DTpk2GLlOmjK8N\nfB98Tdb8DrNHxYkP2GvncQ34vTb+HgmaCDsz4b6MFvbhbP/G98V96/IweYyyDuKjsnYVa+ZzuvzE\nIP3gSm7g8nZdSQZsXq4r8X3QBO76hSmEEEIEQBOmEEIIEQBNmEIIIUQAIppUkyZNMvS1115raC5i\n/NRTTxma/RLAH7vJsWc7duww9Lx58wzN8YTsBXJy9okTJ/rawAmHOUE7F63m9W32wzgxOsc38j3Z\nzjlkyBBDsw/Hibs5yTVfg+MIY2NjfW1g72j37t2GZn+jadOmvnOcD9hHYw+EvT+ODbQVDedz8jHs\nL7J/xNfgNnFsL49rwJ/Mnj1GHpccE8m+qe0a6eFYXsC/R4C9Vn5n2evhccmxn9yPtmfB8aPsQdti\np883roLRrkLLNg/sXOMF+e/R+o+A24NkzV6uS/OYtHnWrrhLbqPrWbi0zQN3JZGXhymEEEJkIpow\nhRBCiABowhRCCCECENHDvP322w3N3gMXkK5Xr56h2esDgKuuusrQ27ZtMzTntoyJiYl4zvr16xua\nPUuOJQWAkSNHGprXzOvUqWPo9u3bG5pjItetW2doLpzN9wD4851ybCjHTbZq1crQnJ+Wvdvk5GRD\njx492teGNm3aGJoLabMXm1WwT8ae1v79+w3N45K9P8Dvrbj8P47/ZU+YvR/2QGyeCMd2cr5Z/rst\nnjQ9Bw8eNDTHbdpiC6+44gpDcxw0e1J8H+yBcl9zm2zxv9xOjnvOjsLlrtg+VxyfDZcXx7i8PP67\ny58E3LHzrhhHHkPcJpc/CfjHFJ+T2x2thxnk2bjez6AFxPULUwghhAiAJkwhhBAiAJowhRBCiABE\n9DC5xmL37t0NzXUiXb4QAHz++eeGZj/K5R2tXbvW0JUqVTI0x7axpwIAtWrVMnTNmjUNPWvWLENz\njs4bbrjB0LNnzzY0e6AVK1b0tYF9G/Y0+T449pDX/RMTEw3NMXjsV9quwbGd7ElnFVzrk2P9OHZw\n586dhrb5ERyzxv3J3g176eyr8DhlP8kWA8leK/tJ7IXz3/mcHPPIsaahUMjXBvYwXbUneZy5csty\nvKotbyifg58v91NWwH3JuOo+2jxrHocuj9KlXbmdg9Tw5HhS7muXl8fjheMZbTWQef8Ae5qufuG+\n5XcvSMxsUI/ShX5hCiGEEAHQhCmEEEIEQBOmEEIIEYCoPMx3333X0OwPshfBcWWAPwaLPRXOZ8qx\naj169DB0UlKSodkfYc8T8NftXL9+vaE5hvHJJ5809ObNmw3NPix7okuWLPG1YcqUKRGvuXz5ckOX\nLVvW0JxTlz0Y1rVr1/a1gb0//gx7DVkF5/JlT4PHGfso7P0B/lhOm8eYHs7jyb4Ij+3vv//e0LYY\nSq5nyffBHjL//corrzQ052nlMcK5nwG//8v35fJ62Htnz5LHpc3bYw9q+/btEa+ZFbhqUbr8wbOJ\ny3TFH/IY5HHN/Wjz7nicc5xktL4ofx+z/2iLgeZrujxNvm++z2jjNG2craepX5hCCCFEADRhCiGE\nEAHQhCmEEEIEIOICNq8ts3/BnsyCBQsMbcsJyR4jx+3s3bvX0B07djT0woULDc0e6J49ewzdsmVL\nXxv4HBzrOXToUEP/85//NPRHH31kaI6BbN26dcTzA8Ann3xi6FWrVhm6S5cuhl69erWh2a+65ZZb\nDM3+F8eKAkDnzp0NzV4t931WwX4gx36lpqYa+qeffjL0Nddc4zunK0cqe5L8zH788UdDs9/Ln+c4\nTsCfV5U/wzU1uQYq+/98D/w+2mIsXXUAXbGD7C/xOORnYYvNZg+La9ra+u584/IXXcfbPE6XJ+mC\nPUmXp2mDn5/Ls2Q4TtPl5fL3sQ1XLliXRxmtF5zRv50N+oUphBBCBEATphBCCBEATZhCCCFEACIu\naPMa+vjx4w3NHhd7KLaYnAMHDhiaY7C4VhrnQH3mmWcM3bBhQ0NzHlJbjkj2HLkOZJUqVQx95513\nGvrpp582NNfXfP755w3NcZmA32vla3J9TPbQ2E+eNm2aodkbHjJkiK8Nb7zxhqH52dhqGWYF7M2w\nH8t+JPuNthhI7m/2yjl+kGOMOWaVY8M4zpW9QsDv77FHyd4d147lMcBeLXuifM+Afw8Bx8i5fDb2\ngjh2NEjsLvctf89wv2QHLt+Msf2d+zLaWE7X8Rxjacvby8+DPxNtHKYr5tFWV5TfhWg9SsYW25se\nm//M7Qrie9rQL0whhBAiAJowhRBCiABowhRCCCECoAlTCCGECEBEx7du3bqG5g05NpM5PbxJAQCq\nV69u6Hnz5hmaC0LfddddEf/OpjUnW+/fv7+vDdddd52heeMDbzp45513DJ2QkGDojRs3GpoTXNuM\ncN74wBtuOACYN4ysWLHC0EWKFDE0b7hauXKlrw2XX365oV9++WVDc2LtrII3gXA7eDMMP78gxXx5\nYxCPIx673P+cCJ3bYEuE7SoCzgW9eWMRFyLnNgcppMsbqnhTnKtANN8nb+jg7wT+zgD8G0+aNGli\naB6XWQGPmWgTFwTBtUGGEzpwG7gv+e/8ecC/6edcCyq4kgZwcnbA/y7xe+C6L9ezcCXfAPwbsHgc\na9OPEEIIkYlowhRCCCECoAlTCCGECEBED3Pbtm2G/u677ww9cOBAQ8+ZM8fQtiK9O3bsMDQnnG7a\ntKmhuTgzJ2pmn2fAgAGGthWxZu+Hk3lHG0CekpJiaF5Dj4uL87WhcuXKhl68eLGhec29QYMGhmYv\nlz22999/39CcaB0A9u3bZ2j2k1u0aOH7TFbAz4c9Ck7awH1l84x5HHHScPY02Ufjsc/X4HFmC77n\nRAKcGIITMLBPyj4LF5BmL8iWwIH9I9aupPTs/fA12W+2PQu+b042wkk3sgJXIHtmJO+29UV6+HuD\n28T+o6sws+0z/Lxcvuq5Jl8A/D63K/m6y7vlNvD5eU6wndPlF2eEfmEKIYQQAdCEKYQQQgRAE6YQ\nQggRgIgeJq/r9u7d29DsYd52223OC/KaOHtxa9asMTQnyeZ4xTp16hg6OTnZ0LZYNI4VY3+qXLly\nhu7UqZOhucBx48aNDc2eJSd7B/z+0g033GBojif9+uuvI36evSO+By5YbTumePHihuaE41nlabIH\nwZ4FPy/2wW2wL83jkH0VTvh+4sQJQ7PHyeOSNeD3Wjhelz1M9p/4feQ9AuzL2PYQ8DEuP4kLCLPH\nxeOQ+80GxxhzoWtbu8837Ae64DHpikkH/N9F0fY9XyPINV3xh65E5i54TNr6kf/NFWfpejf5+8FV\nFB1we9LyMIUQQohMRBOmEEIIEQBNmEIIIUQAInqY7C08++yzhu7atauhOc6M48QAYMuWLYbmIrjF\nihUzNPsZHKPFHsqhQ4cMzQWqAX+x5kGDBhma4yw5RpKLBXNsKefrtBXlXb9+vaHZi+U4TfYrOIaS\nc/Ru2rTJ0OyJAv740tjYWEPbfM+swOVhsU/GcVrs/QD+eEL2NPmanGOVfRiOX2RfhQsrA36Pkp85\nj2VXXlfOH+zyfmzn4Pvmd5aPd+UBZY/U5uXyO8zPxlb0/c9OkL7md5ifF3uc3NcubMWgXbljXXGW\nLq+Pn7fNw4y2WDP3A2v2LFnb4l0zK65WvzCFEEKIAGjCFEIIIQKgCVMIIYQIQEQPk2P7mjdvbmjO\n68re4Oeff+47Z9u2bQ3NeSXZi+N1fPYKOMcqY6vJyZ9hL2/s2LGGZq+J84RynlaOT7399tt9bWDv\niDXHSL7++uuGbtiwoaG5Dl3p0qUNXb9+fV8b+D7YX+bYw6yC74X9RvbNOE+szTNmb5zPwWOAvR8+\npyt2zJZLtlq1ahGP4Rqprmuy58mft9WVZI+SPSjuF94T4PLhOAbOFivoiqtz5Vw9H5xNjtT02OK9\n+XlxX7Dn6Mq5avMo02Mb99HmgmV4Hwvfgyu3sO2arvt0xWmeTa3SaGM9M0K/MIUQQogAaMIUQggh\nAqAJUwghhAhAxEVx9hM59q99+/aGfuWVVwzNOVgBv4fCeUFr1Khh6C5duhh6/Pjxhn7++ecNzT7q\njTfe6GsD+yzs1Xbr1s3Q7Km8++67hmYPjb1eW1wZ5z/leFHOiVumTBlDs+e5bt06Q7O/3Lp1a18b\nOB6O40ldnsn5gmtVsqfJ7eL4X5t/yF4Mexbsvbiuwc+c4ZhWwJ9Dlf1D9iT5GuxRcpvZT7J50Dz2\n+X1kzce7vB8+3uZpcZwyP98gOVIzG24nv/N8X3zfNt+M+4rviz/Dz4+9vmjjOjNqV6S/R6vP1SMF\n3PUwXffNOkg91bONy9QvTCGEECIAmjCFEEKIAGjCFEIIIQIQ0aTavHmzoQsVKmTolStXGprXszlf\nKuBfb2b/gmswcn1MXufnfJobN240dN++fX1t4BjFCRMmGJr9K24zx0iWKFHC0FdeeaWhbTlZ2QPh\nc9SqVcvQ27ZtMzR7lo0aNTL0tddea+jU1FRfG9gT42M4bjCrYO+N/SSO22NPzJZL1uW9paSkGJp9\nFfYwOT6RPWZ+noDfs+T75Pti75s9Th6n7GvzuwX4/fpo40nZV2P4O8KWU5f/ja/B95kd8PiIVtv+\njWM1eVy7vttcnrVtz4GrtqyrVqXNFz1XXPlpWfN9n41PqlyyQgghRBaiCVMIIYQIgCZMIYQQIgAR\nPUz2QNib++qrrwzNa8023ywuLs7QXA+TPRD2jkqVKmVozjN62223Gfqdd97xtYE9SfaW2KPkGL7P\nPvvM0OwTJCYmGprjVQHg1VdfNTTXv+Q2cNxmzZo1Dc2eGteM/P77731tYC+J6xJmVy5Z9tnYa2Wv\nhr0+9jQBv7/Hz9xV14/zsrLvxrlqbT4qxxy74vS4zTzOGPZ+bLUJ+Z3ka/B9cU5dfhdcNTv5eMD/\nzn7zzTeGvuyyy3yfOd9wzmr2sF1xmDZcfi8/f5efGCRvq6sNLu+Vv39d+Yz5XbT1C/cd44q7jLae\npu3v/G7xOZVLVgghhMhENGEKIYQQAdCEKYQQQgRAE6YQQggRgIibfnjjAhujvCmoVatWhl61apXv\nnJyYgKlUqZKhOQE1m/O8SYGPtyXi5k0kbADzZhfelMCbnTp27GhoNp03bNjgawNvbGADPykpydDc\n93wPFSpUMHSTJk0MvWvXLl8bateubWjezMTFvbMKHne88YT7gjfs8EYWwL1RgDftHDhwwND8vFzX\n5EQIgH/zAwemc3J2DnTnz/MmLcaWIJ43SNk2BqWHxwBvCuH75oQNvBkN8D8/3sgXZDNLZuPa1ONK\nQnA21+DvHddGI96AkxnFEc41OTtvsHNt8AGiLwjNG5dcm6Fsyft53Lr6PiP0C1MIIYQIgCZMIYQQ\nIgCaMIUQQogARFwE50QFHOhep04dQ3MRZFvwNvsTXJT622+/NTSvmXPQM6/r//TTT4bmwGobu3fv\nNjT7Muw1dejQwdC8Zv7pp58amj0awL/2P2vWLEM3a9bM0Jy4gK/JhX+5Dddff72vDeyTcuFV9umy\nCh43PGZ4HPKYsCX8Zp+DEztwYgIOuOe+YP+IE4bzOASAq666KuJn2O/jBA58n3v37jU0+2o2D5P3\nHbA3y+OKPU9+Fi7/if1nwH+f/H4FeWczm2i9PNd9A+5EBK5k6q4kAfwdEqSANF+Tn4/rnXcVCLc9\nu2iLUrNnyWPW5bvbPHDuS/6uk4cphBBCZCKaMIUQQogAaMIUQgghAhDRw+RYsho1ahiaE6Oz98ex\ngIC/6DSvebvi4dg/3Lp1q6HZO4qPj/e1YcGCBYbu16+fobk486ZNmwzNsaCcFJtj0bgQN+AvYj1x\n4sSI12S/4r333jM0J51nL4LvGfB7fTt27DC0re+yAh5XoVDI0MWLFzc0e2Acowr4/Tz2QTg5PXt7\n7GnyM2ffxRYLyj4ze5T8LrAnxddg/4k9Te4XAKhYsaKh2aNkf5F9VvaXuR/4HmyxojzueB8DF1yP\njY31nSOzYY+L+/psEoKzT+byC6P1MIPEYbqSirs8ThfcBls/ROv/smfJBQNccZi898bWBm63rUiA\nDf3CFEIIIQKgCVMIIYQIgCZMIYQQIgA5PDYphBBCCOFDvzCFEEKIAGjCFEIIIQKgCVMIIYQIgCZM\nIYQQIgCaMIUQQogAaMIUQgghAvD/fhh+JqDhA84AAAAASUVORK5CYII=\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcwAAACmCAYAAABXw78OAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJztnXd4VVXaxRdFVMrQlAGRIsgNvQak\nQ0ITUCmCKEV0YCCKgsJYUD8rqAPMKM1ehiIISFEUkBoglCggCkoVhFAEgYCKDeR8f/DcTPY6O3ef\nCyFRZv2ehz9W7in7nLPP3dy99vu+OTzP8yCEEEKIiOTM7gYIIYQQfwY0YAohhBAB0IAphBBCBEAD\nphBCCBEADZhCCCFEADRgCiGEEAHQgBmAffv2ISYmBg8//HB2N0UIxMfHIz4+PtvOP2vWLMTExGDW\nrFnZ1gYRnOTkZMTExGDs2LHZ3ZQ/PbmzuwGZwaxZszB06FBceuml+Oijj1CqVCnrdvHx8ShZsiQm\nTZoU1fGLFi2K0aNHo2TJkpnRXPEHINxn0nPJJZegUKFCiImJQbNmzdC5c2fkz58/m1qYMU888UR2\nN0FkI57nYf78+fjggw+wefNmHD9+HAUKFECJEiUQHx+Prl274q9//Wt2N/Oi5KIYMMP8+uuveOaZ\nZ/Daa69l6nEvv/xyXH/99Zl6TPHH4MYbb0TLli0BAKdOncKhQ4ewZs0aPPvss3jttdcwcuRINGjQ\nIJtbadKsWbPsboLIJk6cOIF7770XycnJqFy5Mm6//XYUL14cR48eRXJyMsaNG4dJkyZh9OjRqF+/\nfnY396Ljohowr7vuOixfvhwLFy5E69ats7s54k9AKBTy/Weob9+++PzzzzFgwAAkJCRgypQpqFKl\nSja1UIizeJ6HwYMHIzk5Gffffz/69++PHDlypH1+5513YuXKlbjnnnswcOBAzJ8/H0WLFs3GFl98\nXFQe5t///neUKVMGw4cPx08//eTc/syZM5g4cSI6duyIGjVqoEaNGrjpppvw5ptv4vTp02nb2TzM\nU6dO4T//+Q86duyI2NhY1KpVC+3atcOYMWPw22+/AQAGDRqEmJgYbN682Xfu3377DbGxsWjRogWU\nnfCPR40aNTB69Gj88ssvGD58uPHZe++9hy5duqBGjRqoVasWOnXqhEmTJuHMmTNp24T7zKOPPood\nO3agb9++iI2NRfXq1dGjRw9rn1ixYgV69+6N2NhYVK1aFfHx8Rg2bBiOHTtmbGfzMBcvXoxevXqh\nYcOGqFatGuLi4vDYY4/hwIEDvvMEaT8A/PTTTxg2bBgaN26MatWq4YYbbpBvmY0kJiYiKSkJrVu3\nRkJCgjFYhmnSpAkGDx6Mtm3b4scff4x4vH379mHo0KFo3LgxqlatikaNGmHIkCH4+uuvfdt+8cUX\nGDhwIOrXr4+qVasiLi4OgwYNwq5du4ztwv72+++/jyVLlqBz586oUaMG6tati/vuu8/Xl/9sXFS/\nMPPkyYP/+7//Q9++fTF27Fg89NBDEbd/7LHHMHPmTDRp0gRdu3ZFrly5sHz5cowYMQJbtmzBqFGj\nMtx32LBhePfdd9G+fXv06tULuXLlwqeffoqXXnoJ27dvx7hx49ClSxcsWLAAs2fPRtWqVY39V65c\niR9++AF33HGHteOL7KdOnTqoW7cuPv30U6SkpKBUqVJ4/vnn8fbbb6NFixbo1q0bTp8+jWXLlmHY\nsGHYunWrb3A9fPgw7rzzTrRv3x7t27fH9u3bMXHiRCQkJGDp0qXIkycPAGD27NkYOnQoypUrh4SE\nBBQpUgRffvklpk6diqSkJMyaNQt58+a1tnPevHm4//77UaNGDdxzzz0oUKAAdu3ahYkTJyIpKQkf\nffQR8uXLBwBRtf/BBx/EokWL0KJFC8TFxeHEiRN4/fXX5Y9lE3PmzAFw9pdkJHr37u08VkpKCrp2\n7YrcuXPj1ltvxdVXX429e/finXfeQWJiIt59911UqFABALBlyxb06tULhQsXRv/+/XHFFVdgz549\nmDhxIlatWoW5c+eiRIkSxvFXrlyJtWvXomfPnihWrBgSExMxf/58nDp1CuPHjz/HO/AHwLsImDlz\nphcKhby1a9d6nud59957r1e5cmVv27ZtxnZxcXFez549Pc/zvI0bN3qhUMj729/+5p05c8bYrl+/\nfl4oFPI2btzoeZ7npaSkeKFQyHvooYfStqldu7bXvn17X1teffVVb8CAAd7Jkye933//3WvevLlX\nr14979dffzW2GzJkiBcTE+OlpKSc/w0QURPuM6+++mrE7caMGeOFQiFv7ty53pYtW7xQKOQ9+eST\nvu3uvfdeLxQKeV9++aXnef/tM6FQyJs3b56x7dChQ71QKOStXr3a8zzP+/nnn726det6DRo08E6c\nOGFs+/rrr/vaGRcX58XFxaXphIQELxQKeUePHjX2XbFihdenTx9v06ZNnud5UbU/vG2PHj2M9+PY\nsWNe/fr1vVAo5M2cOTPivROZS/Pmzb3q1at7p06dimq/tWvXeqFQyBszZkza3wYMGODVqlXL27Nn\nj7Htli1bvEqVKnkJCQlpf5szZ47Xs2dPLzk52dh26tSpXigU8saPH5/2t/B7Vb16dW/fvn1pfz9z\n5ozXqlUrr3Llyr7vwj8TF9WUbJhHHnkEefLkwVNPPZXhdOeiRYsAALfeeqvvF17nzp0BAMuWLcvw\nHLlz58ahQ4ewb98+4+/9+vXDuHHjkDdvXuTMmROdO3fG8ePHjWP99ttvWLp0KerVq4err776nK5R\nZA1XXnklAODo0aOYP38+AKBdu3b4/vvvjX9t2rQBAHzyySfG/sWLF0fbtm2Nv1WrVg0A8N1336Xt\nc+LECbRr1w5/+ctfjG3DfTExMTHDNubOfXaiaMOGDcbfmzRpgjfeeCNtdiOa9q9duzZt2/TvR+HC\nhbUALps4cuQIihYtmva8z5Wff/4ZiYmJqFOnDgoVKmT0g6uuugoVKlQw+nGHDh0wadIk1KtXDwDw\n448/4vvvv0+LGti/f7/vHK1btzaiCnLkyIEqVarg9OnTSE1NPa/2ZycX1ZRsmOLFi+Oee+7BiBEj\nMHv27LQvnfSE597D0w7pueaaawAA33zzTYbnGDBgAIYPH462bduiadOmaNiwIRo3bowyZcoY23Xu\n3BkvvfQSZs+enfaltGLFCpw8edLaLvHHIuxl586dGzt37gQA9OzZM8Pt2TMsXbq0b5tLL73UOHa4\nL4ZCId+2RYoUQaFChSL2xT59+qQt9qhduzaaNGmChg0bonr16sZgF037U1JSAABly5b1bVO+fPkM\n9xcXjpw5c2bKeoc9e/bg1KlTWLFiBerWrZvhdj/88AMKFCgAz/MwZcoUTJ8+Hbt378avv/5qbPf7\n77/79o3U70+dOnWeV5B9XJQDJnB2Hn/27NkYOXIkWrRogYIFCxqfhxcFXX755b59L7vsMgBn/yeW\nEbfffjvKly+PiRMnYuXKlVi8eDEAoHbt2njyyScRExMDAChZsiQaNmyIlStX4siRI7jiiiswf/58\n5MuXL20AFX9cwjMIxYoVw8mTJwEA//73v3HFFVdYtw//Ig0T9igjEakvAmf74/fff5/h/jVr1sTM\nmTPx1ltvYfHixVi/fj1efPFFXH311XjooYfSVoxH0/5w3w+/C+kJf/GJrKVYsWI4ePAgfvvtt0D9\nKiPCi4EaN26Mfv36Zbhd+DmPHj0aL7/8MsqXL4+HHnoIpUuXRp48ebBz5048/fTTEfe92LhoB8zc\nuXPjiSeeQM+ePfGvf/3L92DDCyhsq2nDfwsvlMiIRo0aoVGjRvjll1/wySef4MMPP8QHH3yA3r17\nY+HChWnTazfffDOSkpKwYMEC3HzzzVi6dCnatWuX4Rek+OOQlJSEHDlyoE6dOmmLLkqVKoXq1atn\n2jki9UXg7ODl6ovly5fH8OHD8cwzz2Dz5s1YtGgR3nnnHQwcOBCTJ09GbGxs2jGCtD88UPKviUjt\nFBeWWrVqYe/evfjkk0/QuHHjiNumpqaicOHC1s/CyThy5syJ6667LuJxTp8+jYkTJ6JgwYKYPHky\nihQpkvZZOBrgf4mL0sMMU7duXXTs2BEzZszAF198YXx27bXXAgC2b9/u2y+8rLpcuXKBznPZZZeh\nadOmGDFiBHr37o3U1FTDA2jZsiUKFSqEefPmYdmyZfjpp5/QqVOnc70skUUsWrQIO3bsQKtWrVCk\nSJG0PsNeIXD215ttcAlCpL743Xff4cSJE4H7Ys6cOVG9enUMGTIEI0eOhOd5WLhwoXGeIO2/6qqr\nAMDn0QPAjh07ArVFZC7h74xXXnkl4tTszJkzER8fn7ZOgylbtiwuueQSbNq0yTo9mj70IzU1FSdP\nnkRMTIwxWALAunXrzuUy/tRc1AMmcHZpfP78+fHEE08Yc+3h6dBp06YZnc/zPEyfPh0AMkx+sHnz\nZrRp0yZtu/SE//eWfsokT5486NChAzZs2IAJEyagbNmyiI2NPf+LExeMdevW4dFHH8Vf/vIXPPDA\nAwCQtnhn6tSp+OWXX4ztR44cifr162Pv3r1Rn6tevXooUqQI5s2bhxMnThifTZs2DQAynL7/5Zdf\ncMstt1hDqLgvRtP+8AKPBQsWGNsdO3Yswy9icWFp0KABWrZsiU8//RRPP/20dbBbvnw5nn76aeTN\nmzfD75jLLrsMzZs3R2pqatqsSZiUlBTEx8enpV8sVKgQcuXKhYMHDxrfk9u2bcMHH3wAAL6+dDFz\n0U7JhilatCjuu+++tCnZsBldpUoVdO/eHVOmTEFCQgLi4+Nx+vRpLF26FGvXrsWdd95pXYQBABUr\nVsSll16Kp59+Glu3bkXVqlWRK1cubN26FZMnT0aFChV8aam6dOmCCRMmYOPGjbjvvvsu7EWLwGzf\nvj1tUPA8D0ePHsWqVauwbNkyFC1aFGPHjk3rMxUrVkTv3r0xYcIE3HbbbejWrRty586dll3qpptu\nsi52cBGOHx48eDB69OiBLl26oECBAvj8888xY8YM1KxZE127drXue9lll6FKlSqYMmUKvv/+ezRv\n3hz58uXD/v37MWXKFOTNmzdtcVk07a9evToaNGiApKQkDBo0CI0bN8aJEyfw3nvvoWbNmhFX7YoL\nx4gRIzB48GBMmTIFq1evxo033ojSpUvj2LFjWLNmDRITE1G6dGm88sorGU7JAmd/SKxbtw5PPfUU\ndu3ahUqVKmH//v145513kCNHDnTr1g3A2fzKrVq1woIFC/CPf/wDTZs2xZ49ezBlyhSMGjUK/fv3\nx5o1azBr1qxsLQiQVVz0AyYA3HbbbZg1a5Yvu8rjjz+O8uXLY/r06Rg+fDhy5syJa6+9FsOGDcvw\nCwo464++8847ePnll7FkyRLMnj0bp06dQsmSJdGjRw8kJCT4TPlQKIQqVapgy5Yt6Nix4wW5ThE9\nc+fOxdy5c9N0/vz5Ua5cOQwaNAg9evTwhXk88sgjqFChAqZNm4bnnnsOZ86cQdmyZfHAAw/gjjvu\nOOd2tGvXDgULFsSrr76ali2qZMmS6NevH/r37x9xkcfjjz+OcuXKYc6cORg1ahR++uknFClSBPXq\n1cNdd91lTOdG0/4xY8Zg5MiRWLx4MZYsWYIyZcqgT58+uPLKKzVgZhP58uXDq6++ikWLFmHOnDl4\n9913cfz4ceTJkwcVKlTAk08+iY4dOzrXR5QuXRozZszA+PHjMXfuXEycOBEFChRAvXr1cPfdd6Ni\nxYpp2z755JPIkycPVq1ahcTERFSpUgXjxo1DbGws7r77brz55psYOXIk6tSpc6EvP9vJ4WXGOmXh\n5OTJk4iPj0dsbOyfO9OFEEL8j3LRe5h/FF5++WUcP34cffr0ye6mCCGEOAf+J6Zks4sjR44gOTkZ\nq1evTkt4Xbt27exulhBCiHNAU7IXkPXr16Nnz57Inz8/OnTogAcffPC8Ao6FEEJkHxowhRBCiADI\nwxRCCCECENHDvOuuuwzNBWY5ITRXpf/22299x+RaeumXLwP/DdQOkzOnOaaHKz2E4WwTfDxbGzhB\nOk+Tpi8eDZyt7ZaeWrVqGTqcQSVM5cqVDW3Lx1msWDFDr1+/PuIxV61a5TtGpHPy8W1prDjIngOQ\nuf7i7bffHrENmUWhQoUMzbX2ePk690tb3lWuPF+8eHFDh/Oshtm0aZOheZn+xo0bDc1B4rak5VzQ\nl4vpchv5eXBcXaVKlQzNhQT4fQT+m8wgzKFDhwzNae/4Pv3www+G5vvGxw9iQfB94IxJDRo0cB7j\nfAlnNgrDSQFcaeBsCchd8L3JlSuXoS+55JKI2/PntvytrmO4jsnfXfxu8neprd+XKlXK0Fyhid8t\nfn+5f/DnnPObMxLZzsn9lN/NjFJH6hemEEIIEQANmEIIIUQAIk7J8nQmT5Xw1NjRo0cNzQnPAfiy\n7Ifr7oW5++67Db18+XJDc/kknjrh4qovvPCCrw0PP/ywoXk6huECwDxdx1MOnJyap7UA/3TnkSNH\nDL17925Dd+/e3dA8dcb3nqd4bW3gdvPUxrlMM2UGPOXNUzB8rdwveZoR8D9jnori6c/0xW8B/7Qv\nT3/yvbJNC/E5OI0eT/txYXOGn9fBgwcNbStOzudg+4Gnx/hznpLjTEj8bGzFjgsUKGBotl2yo9/x\n83W1gT+3bc9TrKxduKZo+TuE72OQc7r6A98X1q7vTsDfbp4O5T7En3MpOs63zLaAzQbgv51rH9Mv\nTCGEECIAGjCFEEKIAGjAFEIIIQIQ0cPkuWGeD9+6dauhU1NTDW2r+MHzzzyHPmXKFEPzUmmez+Y5\n9K+++srQAwcO9LWB09NxG9i/4soMfMxwXbgw7NHYQkJ4GTOHw7AH9uWXXxqa70O46HUYflY2D5M9\nZr7u7IKXkTPsrXOog+1a2Zvh+88+C/cJDvngvs5euq3IMvcL9ihdfhFrDgvi9QC2+xgTE2NoDj/i\nMAEOK+D3kb137rccEgT4+x3f+0hlqS4U/L3EXIiwkWg9Tb73tnA1hn1Nl1fLmvs1f87vkS38xhWi\nw8fk68qXL5+h2fPk49nqc/I5eB++LxmhX5hCCCFEADRgCiGEEAHQgCmEEEIEIKKHyV4C+2QcU3n8\n+HFDT5482XfMRx55xNDsR3GKN55b5hi7hg0bGpo9zCVLlvja0KtXL0O/8sorhma/in2eZcuWGZr9\nD44d5Xl+wJ8ikDXHIrHfUbBgQUPXrFnT0OwD8H0B/Pd6y5YthuZ7m1VwLCDfX5d3Y/Oj2P9xpWPj\n+EH2PLiN7GnaYkHZs+S4SYb7BL8rHIfJ/Zbj9AB/ykX2VbkWA/tPfEz2i9kr2rNnj68N3Hc5ttMV\nf3ohcKW+cxHEj3TFAkarz7fNNlyeJcPrXFgD/n7KHiOf05W+z5VukWPUbe0KEkdrQ78whRBCiABo\nwBRCCCECoAFTCCGECEBED5PztrLvw3FgjC225fPPPzc0+4E8/8z5MLmMEpcD4/y2ttJACxYsMDRf\nF8eFsefC5b7YH3z00UcNbfNx6tata2i+7n379hn6wIEDhuZ4OY5NYk+NrwEA9u/fb+jvvvvO0Lbc\nlFkB+w3sJ7KPxvfG5mFwOS6Oy2TvLhQKGZp9FvZJDx8+bGhbLCi/L3ydfE6OL+U8rbxmgH009qgB\n/73j6+Z3gfsAn4PXObD/yPcZ8L8P7GFyLKet72Y2QePwotk/2jhL1zHZswxSOs0Fe3fs5XO/52vi\n98Dm3XMf4e8qhj1P3p77gytWGPDfS5enmRH6hSmEEEIEQAOmEEIIEQANmEIIIUQANGAKIYQQAYi4\n6Me2eCI9rgTgvDAF8C+QadasmaHXrFljaFeRY14UNGfOHEN36tTJ1wZOjF2tWrWIbeJEBHFxcYbm\nBTpsfNsWBLCBz8nVOeEwm+0ff/yxodu0aRNxf15AAvgXofTu3dvQ48aNMzQnR7hQ8CIQXjjCC1E4\niYDNwOfkEbyQiJ8RL37hhSicRCBIcDU/k2uuucbQvMiO28yLsnixA2tbv+NjsnYlDeDP+T7y57aF\nY7yIg7fhguFZAS/048Uu50K0wfH8jvP2/N3HcLITIPrr4s95cQx/b3Gf5ncR8D9v1txP+ZjcBu4f\nfN22+8zt5mPYksvY0C9MIYQQIgAaMIUQQogAaMAUQgghAhDRw2Sfhr295ORkQzdp0sTQtoTf7O1s\n27bN0GXLljU0e0euBNbs5XEgLgDcfPPNhuZAap6HZ4+Tk5RzGznBNRf2BfwJFzghPAfa871lD5P9\nDU4QYUtYfv311xt6xYoVhuYkEVkF+y6cIJw9TQ6MtvkR7P9xsWz2ytkX4fvHidG5z9gKJ3NANR+D\nr5P9JPb6uO/z8W2eFyc/4HPy+8nvG7eJ/SZe98AJHQD/veZ9XF7dhYCv2+X18bOwedbcJ1zJ1xlX\nwWluA783Gf0tEq4C0UyQ5AzcR/jdYo/StT2/i677bGunKyF8RugXphBCCBEADZhCCCFEADRgCiGE\nEAGI6GHyvC77gfw5e57s/QHAqlWrDM3+H3tL7LFw7Cd7UzExMYbmGEnA7+9xoWQuOt28efOI5+D4\nRPaWOKYPABo1amRojj3kOXdOtO3yJjjWlI8P+OOfOA7QlVz/QsEeBXteGzZsMDTHAnJsLuD3yfha\nufgye3fss/D+nBCajwf4vRaOR2PfjJ9ZpUqVDM3XyUnouc/Y/saela0AcHo42TZ7QRzvG6Tf8fvC\nvlnt2rUjtikz4PfN9X7x9rb4Q5fX5orTdMX2stfH36WA/92wxWOnxxbLGQlXMXfAH/PIcerch/i6\n+Lpd9573B/zX5Yp5zQj9whRCCCECoAFTCCGECIAGTCGEECIAET1M9u527dplaJeHYssJ2aJFC0Oz\nZ8m+KMcjsifJsUiuGB7AH6s5fvx4Q7du3drQHPPIXhJ7tW+88Yahd+/e7WsDz7vzfeAYyOnTpxua\n8/RyDl2+bltcIMdhrl692tAcI5tVsJfHeXaZILFg7IOWLl3a0BzD+M033xiaPQ721tmr41hcwO8P\nHjlyJOMGwx0byB4oxzza/Cr2MHkNAF8Xb885OdmPYu+W1xwA/utgH4wLm2cFrmLM3Md4e1vOXNc2\nruLcjK0Yt6sN3K/ZP+Zjcj9mzZ4of4/ZPE2Xd+sqjM2ajxck1pTPca7oF6YQQggRAA2YQgghRAA0\nYAohhBABiCoOc+vWrYbOmzevodkXsvkC7IlwPk32QV05/thn5Ri9cuXK+fbhbT777DNDV6lSxdC3\n3367oblOJHsHHJdpiwtiz3LChAmGbteunaFdtQ85ry/XtrTFia1cudLQnPu3bt26vn2yAo7/5Lg8\n9izYn7Xdb4Zjv9hfZP+P28BeH8dt2mIg2S9i/4+9cH7G3CaOi+Y4PFsbOJfs9u3bDc3xpQxfJ/tu\n/J3AnhfgjsPjWM+swOVRMkHi9tg3c8VZus7B98nlJwLunLech5mP6fITuY+6rglwe5j8nvAxeczg\nNtjyAPM5XM8mI/QLUwghhAiABkwhhBAiABowhRBCiABE9DBnzJhh6MaNGxt64cKFhuYYLFstSvYn\neI6d5+E5toy9JI4FZc/Tlg+Vj8FxlZUrVzY0x9TxNbCvw9tz7BMALF++3NDs63C7uU0cI9m/f39D\n87y+7VnwXD/H2bJPl1V8/fXXhmZ/gZ8554m13W/25tiz5Jhhjp3lNnAMJPuqtpg5V8wbrwFITU01\nNPcR3p6PZ8thzHGX3C88zzM0+6J8nXxf+f3lawD87x+3IdoajlmBy/MK4oFFG+vp0tyfbLGG/H3I\n3wvsObP/z8+T47v5PbDBz5vfTz4Hx45Ge99ctUwB//NSPUwhhBAiE9GAKYQQQgRAA6YQQggRgIge\nJue65JitDh06GJpjHqdNm+Y7JvuFHAvYrVs3Q7OfNWLECEO/9dZbhm7SpImh2V8EgAoVKhiavTrO\nXcpz4hwHVKdOHUOzP2nzceLj4w3NdUKLFStmaI4V5djQdevWGbply5aGfumll3xtYF+0ffv2hg4a\nm5TZ8DPjOEv2TdgDscX+sSfJz4R9EvZFuQ+w58l+EvuLgD+vKns17I1zm9m3Zi+Xj1e2bFlfG9jD\n4uvge8t1Pl01GTmuz5YXlu+tKy9vVsA+W7T1EoPkM4429s+VQ5W9QJuHycfgfWx+f3r4ulzxjLb7\nwG3gfdiz5j7q8rTPJU8s78MxrhmhX5hCCCFEADRgCiGEEAHQgCmEEEIEIKKH2aNHD0NzLcqlS5ca\nmn0h9ukAfx5X9i9SUlIMzflM77vvPkNz/OELL7xgaK75CPi9H87hyXFhL7/8sqE5XrFTp06GDoVC\nhq5ataqvDVxjk/0nnsfnOqKTJ082NOfU5WfFHg3gjme01fHMCtiz5NhAzqnK3qDN8+Acqpxnlb07\nV05N7gPs5dl8OI5p5L6/Z88eQ3MtWH4+/Ez5vnFcNOC/N3xf+D6wl+7yetgT5TbbjsGxgPwuZAXn\n69fbYgX5b67csEGOGQmbH8lencsH5Tayd89tZs8ySAwtt4F9cvbBefsgfjHjyhUcJHYT0C9MIYQQ\nIhAaMIUQQogAaMAUQgghAqABUwghhAhAxEU/SUlJhuZFPW3bto24vS0xLy/qYcOXExn06dPH0LzA\ngxdGcOFlW9JxLt7MSeQ5yfyHH35o6Mcee8zQK1asMDQv8lm8eLGvDbyQhRc68EIINtvLly9vaF4w\nwgtCOFkDAKxZs8bQ/Gz69u3r2ycrYNOfEyPzQhTuQ3wdtmPw/eFkCbwgipNO8/6czN22yIoXFnCb\neCES911uAy+o+fbbbw1tSwDPizp4cZIruQIvuOLvBF6sZktcwN8LfJ3ZsejnfBeW2Ba7uBb9uLQr\n+ToTZOESF7vgxW2uc0SbIB5wJ2Bg7SpazdfAuD63HTMo+oUphBBCBEADphBCCBEADZhCCCFEACJ6\nmJxcnee72SO54447DG0LBl29erWhXcme2efhAHFObMAJAUaNGuVrA3uWHORfvHhxQzdo0MDQ7Muw\nt/T8888bmhPGA8AXX3xhaL4uDjjmhPDXXXedofm+sg/IhYMBv9fKxYBtScyzAg64Z7+BA/65newP\nA/5r42fGvgefg+8n788eaKkL0CrUAAAR+klEQVRSpXxt4OTq7HuyN8v3gRO6s1+4efNmQ5cpU8bX\nBr4OPidrfofZo+LEB+y1c78G/F4bf4/Ykh1caPheRgv7cLa/8b3he+vyMLmPsg7io7J2FWvmY7r8\nxCD3wZXcwOXtupIM2LxcV+L7oAnc9QtTCCGECIAGTCGEECIAGjCFEEKIAEQ0qV555RVDX3vttYbm\nIsbPPPOModkvAfyxmxx7tnPnTkPPmTPH0BxPyF4gJ2cfP368rw2ccJgTtHPRap7fZj+ME6NzfCNf\nk+2YDz/8sKHZh+PE3Zzkms/BcYSxsbG+NrB3tHfvXkOzv9G0aVPfMS4E7KOxB8LeH8cG2oqGc9Fv\nhv1F9o/4HNwmju3lfg34k9mzx8j9kmMi2Te1nSM9HMsL+NcIsNfK7yx7PdwvOfaT76PtWbBHyR70\nuRQEPl9cBaNdhZZtbT7feEH+PFr/EXB7kKzZy3Vp7pM2z9oVd8ltdD0Ll7YltXclkZeHKYQQQmQi\nGjCFEEKIAGjAFEIIIQIQ0cPs3r27odl74ALS9erVMzR7fQBw1VVXGXr79u2G5tyWMTExEY9Zv359\nQ7NnybGkADB8+HBD85x5nTp1DN2+fXtDc0zkunXrDM2Fs/kaAH++U44N5bjJVq1aGZrz07J3m5yc\nbOiRI0f62tCmTRtDcyFt9mKzCvbJONfokSNHDM39kr0/wO+tuPw/jv9lT5i9H/ZAbJ4Ix3Zyvln+\n3BZPmp5jx44ZmuM2bbGF7OVyHDR7Unwd7IHyveY22eJ/uZ0c95wdhctdsX2uOD4bLi+OcXl5/LnL\nnwTcsfOuGEfuQ9wmlz8J+PsUH5PbHa2HGeTZuN7PoAXE9QtTCCGECIAGTCGEECIAGjCFEEKIAET0\nMLnGYo8ePQzNdSJdvhAAfPbZZ4ZmP8rlHa1du9bQlSpVMjTHtrGnAgC1atUydM2aNQ09Y8YMQ3OO\nzhtuuMHQM2fONDR7oBUrVvS1gX0b9jT5Ojj2kOf9ExMTDc0xeOxX2s7BsZ3sSWcVXOuTY/04dnDX\nrl2GtvkRHLPG95O9G/bS2Vfhfsp+ki0Gkr1W9pPYC+fP+Zgc88jxq6FQyNcG9jBdtSe5n7lyy3K8\nqi1vKB+Dn2925JLle8m46j7aPGvuhy6P0qVduZ2D1PDkeFK+1y4vj/sLxzPaaiDz+gH2NF33he8t\nv3tBYmaDepQu9AtTCCGECIAGTCGEECIAGjCFEEKIAETlYb7//vuGZn+QvQiOKwP8MVjsqXA+U45V\n69mzp6GTkpIMzf4Ie56Av27nhg0bDM0xjE899ZSht2zZYmj2YdkTXbJkia8NEyZMiHjO5cuXG7ps\n2bKG5py67MGwrl27tq8N7P3xPuw1ZBWcy5c9De5n7KOw9wf4YzltHmN6OI8n+yLctw8cOGBoWwwl\n17Pk62APmT8vUaKEoTlPK/cRzv0M+P1fvi6X18PeO3uW3C9t3h57UDt27DC0K/70QuCqRenyB88l\nLtMVf8h9kPs130ebd8f9nOMko/VF+fuY/UdbDDSf0+Vp8nXzdUYbp2njXD1N/cIUQgghAqABUwgh\nhAiABkwhhBAiABEnsHlumf0L9mTmz59vaFtOSPYYOW5n//79hu7YsaOhFyxYYGj2QPft22foli1b\n+trAx+BYz6FDhxr6n//8p6E//vhjQ3MMZOvWrSMeHwA++eQTQ69atcrQXbp0MfTq1asNzX7VLbfc\nYmj2vzhWFAA6d+5saPZq+d5nFewHcuxXamqqoQ8fPmzoa665xndMV45U9iT5mR06dMjQ7Pfy/hzH\nCfjzqvI+XFOTa6Cy/8/XwO+jLcbSVQfQFTvI/hL3Q34Wtths9rC4pi3nq80KXP6ia3ubx+nyJF2w\nJ+nyNG3w83N5lgzHabq8XFfdWcCdC9blUUbrBWf0t3NBvzCFEEKIAGjAFEIIIQKgAVMIIYQIQMQJ\nbZ5DHzt2rKHZ42IPxRaTc/ToUUNzDBbXSuMcqM8995yhGzZsaGjOQ2rLEcmeI9eBrFKliqHvvPNO\nQz/77LOG5vqaL774oqE5LhPwe618Tq6PyR4a+8mTJk0yNHvDDz/8sK8NU6dONTQ/G1stw6yAvRn2\nY9mPZL/RFsfH95u9co4f5Bhjjlnl2DCOc2WvEPD7e+xRsu/JtWO5D7BXy54oXzPgX0PAMXIun429\nII4dDRK7y/eWnxd7tdmByzdjbJ/zvYw2ltO1PcdY2vL28vPgfaKNw3TFPNrqivK7EK1Hydhie9Nj\n85+5XUF8Txv6hSmEEEIEQAOmEEIIEQANmEIIIUQANGAKIYQQAYjo+NatW9fQvCDHZjKnhxcpAED1\n6tUNPWfOHENzQei77ror4udsWnOy9f79+/vacN111xmaFz7wYoz33nvP0AkJCYbetGmToTnBtc0I\n54UPvOCGA4B5wciKFSsMXbhwYUPzgquVK1f62nDllVca+vXXXzc0J9bOKnixGbeDF8Pw8wtSzJcX\nmnA/4r7L958ToXMbbImwXUXAuaA3LyziQuTc5iCFdHlBFS+KcxWI5uvkBR38ncDfGYB/4Unjxo0N\nzf0yK+A+E23igiC4FshwQgduA99L/pz3B/yLfs63oIIraQAnZwf87xK/B67rcj0LV/INwL8Ai/ux\nFv0IIYQQmYgGTCGEECIAGjCFEEKIAET0MLdv327ob775xtADBgww9KxZswxtK9K7c+dOQ3PC6aZN\nmxqaizNzomb2ee6++25D24pYs/fDybyjDSBPSUkxNM+hx8XF+dpQuXJlQy9evNjQPOfeoEEDQ7OX\nyx7bhx9+aGhOtA4ABw8eNDT7yS1atPDtkxXw82GPgpM28L2yecbcjzhpOHua7KNx3+dzcD9jHxzw\nJxLgxBCcgIF9UvZZuIA0e0G2BA7sH7F2JaVn74fPyX6z7VnwdXOyEU66kRW4AtkzI3m37V6kh783\nuE3sP7oKM9v24efl8lXPN/kC4Pe5XcnXXd4tt4GPz2OC7Zguvzgj9AtTCCGECIAGTCGEECIAGjCF\nEEKIAET0MHlet3fv3oZmD/O2225znpDnxNmLW7NmjaE5STbHK9apU8fQycnJhrbFonGsGPtT5cqV\nM3SnTp0MzQWOOY6MPUtO9g74/aUbbrjB0BxP+tVXX0Xcn70jvgYuWG3bplixYobmhONZ5WmyB8Ge\nBT8v9sFtsC/N/ZB9FU74/uuvvxqaPU7ul6wBv9fC8brsYbL/xO8jrxFgX8a2hoC3cflJXECYPS7u\nh3zfbHCMMRe6Zm8uK4j2nNwnXTHpgP+7KNp7z+cIck5X/KErkbkL7pO2+8h/c8VZut5N/n5wFUUH\n3J60PEwhhBAiE9GAKYQQQgRAA6YQQggRgIgeJnsLzz//vKG7du1qaI4z4zgxANi6dauhuQguF49l\nH4ZjtNhDOX78uKG5QDXgL9Y8ZMgQQ3OcJcdIcrFgji3lfJ22orwbNmwwNHuxHKfJfgXHUHKO3s2b\nNxuaPVHAH18aGxtraJvvmRXYvLf0sE/GcVrs/QD+eEL2NPmcnGOVfRiOX2RfhQsrA36Pkp8592VX\nXlfOH+zyfmzH4Ovmd5a3d+UBZY/U5uXyO8zPxnbv/ugEudf8DvPzYo+T77ULWzFoV+5YV5yly+vj\n523zMKMt1sz3gTV7lqxt8a6ZFVerX5hCCCFEADRgCiGEEAHQgCmEEEIEIKKHybF9zZs3NzTndWVv\n8LPPPvMds23btobmvJLsxfE8PnsFnGOVsdXk5H3Yyxs9erSh2WviPKGcp5XjU7t37+5rA3tHrDlG\n8u233zZ0w4YNDc116EqXLm3o+vXr+9rA18H+MsceZhV8Lew3sm/GeWJtnjF743wM7gPs/fAxXbFj\ntlyy1apVi7gN10h1nZM9T97fVleSPUr2oPi+8JoAlw/HMXC2WEFXXJ0r5+qF4FxypKbHFu/Nz4vv\nBXuOrpyrNo8yPbZ+H20uWIbXsfA1uHIL287puk5XnOa51CqNNtYzI/QLUwghhAiABkwhhBAiABow\nhRBCiABEnBRnP5Fj/9q3b2/oN954w9CcgxXweyicF7RGjRqG7tKli6HHjh1r6BdffNHQ7KPeeOON\nvjawz8Jebbdu3QzNnsr7779vaPbQ2OvlmD7An/+U40U5J26ZMmUMzZ7nunXrDM3+cuvWrX1t4Hg4\njid1eSYXCq5VyZ4mt4vjf23+IXsx7Fmw9+I6Bz9zhmNaAX8OVfYP2ZPkc7BHyW1mP8nmQXPf5/eR\nNW/v8n54e5unxXHK/HyD5EjNbLid/M7zdfF123wzvld8XbwPPz/2+qKN68yoXZE+j1afr0cKuOth\nuq6bdZB6qucal6lfmEIIIUQANGAKIYQQAdCAKYQQQgQgokm1ZcsWQxcsWNDQK1euNDTPZ3O+VMA/\n38z+Bddg5PqYPM/P+TQ3bdpk6L59+/rawDGK48aNMzT7V9xmjpEsXry4oUuUKGFoW05W9kD4GLVq\n1TL09u3bDc2eZaNGjQx97bXXGjo1NdXXBvbEeBuOG8wq2HtjP4nj9tgTs+WSdXlvKSkphmZfhT1M\njk9kj5mfJ+D3LPk6+brY+2aPk/sp+9r8bgF+vz7aeFL21Rj+jrDlheW/8Tn4OrMD7h/RatvfOFaT\n+7Xru83lWdvWHLhqy7pqVdp80fPFlZ+WNV/3ufikyiUrhBBCZCEaMIUQQogAaMAUQgghAhDRw2QP\nhL25L7/80tA812zzzeLi4gzN9TDZA2HvqFSpUobmPKO33Xabod977z1fG9iTZG+JPUqO4Vu/fr2h\n2SdITEw0NMerAsCbb75paK5/yW3guM2aNWsamj01rhl54MABXxvYS+K6hNmVS5Z9NvZa2athr489\nTcDv7/Ezd9X147ys7Ltxrlqbj8oxx644PW4z9zOGvR9bbUJ+J/kcfF2cU5ffBVfNTt4e8L+zX3/9\ntaGvuOIK3z4XGs5ZzR62Kw7Thsvv5efv8hOD5G11tcHlvfL3ryufMb+LtvvC945xxV1GW0/T9jm/\nW3xM5ZIVQgghMhENmEIIIUQANGAKIYQQAdCAKYQQQgQg4qIfXrjAxigvCmrVqpWhV61a5TsmJyZg\nKlWqZGhOQM3mPC9S4O1tibh5EQkbwLzYhRcl8GKnjh07GppN540bN/rawAsb2MBPSkoyNN97voYK\nFSoYukmTJobes2ePrw21a9c2NC9m4uLeWQX3O154wveCF+zwQhbAvVCAF+0cPXrU0Py8XOfkRAiA\nf/EDB6ZzcnYOdOf9eZEWY0sQzwukbAuD0sN9gBeF8HVzwgZejAb4nx8v5AuymCWzcS3qcSUhOJdz\n8PeOa6ERL8DJjOII55ucnRfYuRb4ANEXhOaFS67FULbk/dxvXfc+I/QLUwghhAiABkwhhBAiABow\nhRBCiABEnATnRAUc6F6nTh1DcxFkW/A2+xNclHr37t2G5jlzDnrmef3Dhw8bmgOrbezdu9fQ7Muw\n19ShQwdD85z5p59+amj2aAD/3P+MGTMM3axZM0Nz4gI+Jxf+5TZcf/31vjawT8qFV9mnyyq433Cf\n4X7IfcKW8Jt9Dk7swIkJOOCe7wX7R5ww3Ob/8vvE+7Dfxwkc+Dr3799vaPbVbG3gNQDszXK/Ys+T\nn4XLf2L/GfBfJ79fQd7ZzCZaL8913YA7EYErmborSQB/hwQpIM3n5OfjeuddBcJtzy7aotTsWfJa\nGZfvbvPA+V7yd508TCGEECIT0YAphBBCBEADphBCCBGAiB4mx5LVqFHD0JwYnb0/jgUE/EWnec7b\nFQ/H/uG2bdsMzR5mfHy8rw3z5883dL9+/QzNxZk3b95saPaBOCk2x6JxIW7AX8R6/PjxEc/JfsUH\nH3xgaE46z14EXzPg9/p27txpaNu9ywq4X4VCIUMXK1bM0OyBcYwq4I9JZB+Ek9Ozt8eeJj9z9l1s\nPgv7zOxR8rvAnpQrPpU9TVsMMsc5s0fJ/iL7rNwGvg98DbZYUe53vI6BC67Hxsb6jpHZsMfFz/Nc\nEoKzT+byC6P1MIPEYbqSirs8ThfcBtt9iNb/Zc+SCwa44jB5rYCtDdxuW5EAG/qFKYQQQgRAA6YQ\nQggRAA2YQgghRAByeGxSCCGEEMKHfmEKIYQQAdCAKYQQQgRAA6YQQggRAA2YQgghRAA0YAohhBAB\n0IAphBBCBOD/ATl/gSbn/MeDAAAAAElFTkSuQmCC\n",
             "text/plain": [
               "<Figure size 576x396 with 3 Axes>"
             ]
@@ -786,10 +787,10 @@
       "metadata": {
         "id": "DVmDZIRTHPDa",
         "colab_type": "code",
-        "outputId": "11f7bba8-3dad-45da-ca37-e4e32df61fee",
+        "outputId": "94bda2ad-e40e-4c44-e74f-be30d956eed6",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 92
+          "height": 88
         }
       },
       "cell_type": "code",
@@ -810,7 +811,7 @@
         "sgd = keras.optimizers.SGD(lr=0.1)\n",
         "descriptor_model_trip.compile(loss='mean_absolute_error', optimizer=sgd)"
       ],
-      "execution_count": 0,
+      "execution_count": 16,
       "outputs": [
         {
           "output_type": "stream",
@@ -839,10 +840,10 @@
       "metadata": {
         "id": "YIR1cH4fDwKj",
         "colab_type": "code",
-        "outputId": "4be8ee71-fd35-4f78-c7a2-f9f5fa3d4398",
+        "outputId": "b17c0b36-e90e-4df0-e969-0ab13136786d",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 199
+          "height": 187
         }
       },
       "cell_type": "code",
@@ -856,22 +857,22 @@
         "# Creating validation generator\n",
         "val_generator = DataGeneratorDesc(*hPatches.read_image_file(hpatches_dir, train=0), num_triplets=10000)\n"
       ],
-      "execution_count": 0,
+      "execution_count": 17,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
             "Using denoised patches\n",
-            "100%|██████████| 116/116 [00:32<00:00,  3.61it/s]\n",
+            "100%|██████████| 116/116 [00:33<00:00,  3.44it/s]\n",
             "Denoising patches...\n",
-            "100%|██████████| 15589/15589 [04:10<00:00, 62.11it/s]\n"
+            "100%|██████████| 15589/15589 [04:21<00:00, 59.52it/s]\n"
           ],
           "name": "stdout"
         },
         {
           "output_type": "stream",
           "text": [
-            "100%|██████████| 100000/100000 [00:01<00:00, 75013.81it/s]\n"
+            "100%|██████████| 100000/100000 [00:01<00:00, 66375.95it/s]\n"
           ],
           "name": "stderr"
         },
@@ -879,16 +880,16 @@
           "output_type": "stream",
           "text": [
             "Using denoised patches\n",
-            "100%|██████████| 116/116 [00:19<00:00,  2.40it/s]\n",
+            "100%|██████████| 116/116 [00:20<00:00,  2.21it/s]\n",
             "Denoising patches...\n",
-            "100%|██████████| 9525/9525 [02:31<00:00, 62.74it/s]\n"
+            "100%|██████████| 9525/9525 [02:37<00:00, 60.37it/s]\n"
           ],
           "name": "stdout"
         },
         {
           "output_type": "stream",
           "text": [
-            "100%|██████████| 10000/10000 [00:00<00:00, 87264.62it/s]\n"
+            "100%|██████████| 10000/10000 [00:00<00:00, 59634.17it/s]\n"
           ],
           "name": "stderr"
         }
@@ -908,22 +909,22 @@
       "metadata": {
         "id": "3RQmOMU92csu",
         "colab_type": "code",
-        "outputId": "7f37711a-4c53-4135-a5c8-412358dabf99",
+        "outputId": "648c64db-a797-4bb6-c7de-5eb45d27da25",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 184
+          "height": 183
         }
       },
       "cell_type": "code",
       "source": [
         "plot_triplet(training_generator)"
       ],
-      "execution_count": 0,
+      "execution_count": 18,
       "outputs": [
         {
           "output_type": "display_data",
           "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcwAAACmCAYAAABXw78OAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJztnXu4llWZxm+Ug9shI0nESURAv71F\nDm2OSSqOkYICmukoQopKmk1chU46o3goyTRnpgsPhXVZUzYlB0Fy8FRCYKkjaIiZkIISqBttJwhy\nEOWdP7y+3X5/7+JbawsbQu/fdfHH2t/7rXcdnvddfOtez/O0yLIskzHGGGMqstfuboAxxhizJ+AF\n0xhjjEnAC6YxxhiTgBdMY4wxJgEvmMYYY0wCXjCNMcaYBLxgNoHVq1erurpaV1999e5uivmAU7a1\nf/u3f9sp1xnTnHxY7HCPXTBvvPFGVVdXq1+/ftq8efPubo75ADFz5kxVV1cX/h1xxBEaNGiQ/uVf\n/kWLFi1q1ja0b99ekydP1ujRo3N//973vqfVq1dHrzN/35RtrFevXlq1atV2rzv++OP1hS98YRe2\nLI0Pqx223N0NeD+8/fbbmjVrlvbaay+tX79eDzzwgE499dTd3SzzAWPEiBEaMmRIQ3nz5s1asWKF\npk6dqrlz5+rGG2/UyJEjm+XeVVVVGjp0aO5vq1at0uTJk9W3b18dfPDB273O7Dls2bJF1113nX7w\ngx/s7qYk82G2wz3yF+ZDDz2kN954Q2eddZZatGihadOm7e4mmQ8gpVJJQ4cObfh36qmn6pJLLtGM\nGTNUVVWlb33rW9q6desua88zzzyzy+5ldg0DBw7U/Pnz9dBDD+3upiTzYbbDPXLBnDp1qiTp3HPP\nVd++ffXkk09q+fLluWv+7//+T9XV1fre976nJ598UqNHj1Ztba1qa2s1bty44DbIfffdp7POOqvh\nuosuukjPPvtssA3PP/+8zj//fPXp00e1tbW64IIL9Oc//7lw3S9/+cuGOnv27KmhQ4fqu9/9rjZu\n3Ji7rrq6WmPHjtUjjzyiE088UZ/+9Kff7/CYZqZTp04aMGCA1q5dq+eff17Se78Ubr31Vp100knq\n1auXamtrdcYZZ2j69OmF7z/xxBO68MILdcwxx6hnz5469thjNWHCBP3pT39quIaa0Be+8AVNmDBB\nknTOOeeourpaq1evLlx39tlnq6amRmvWrCnct66uTjU1Nblts7/+9a+aNGmSjj/+ePXo0UMDBw7U\nxRdfrKeffnrnDZjZLl/84hfVuXNnfetb3yq8E7bHjBkzdPrpp6t3796qra3V5z73Od15553atm1b\n7roNGzbouuuu09FHH61evXrp9NNP1+9+9ztNnz5d1dXVmjlzZu76++67T6NHj1afPn3Us2dPnXji\nibrxxhv15ptvNlzzYbfDPW7BfPHFF/XEE0+otrZWhx56aMNWbOjFJEnLli3TV77yFfXv319XX321\nTj75ZD3yyCMaP3587ro77rhDEyZMULt27XTNNddowoQJev755zVq1CgtWbIkd219fb0uuugi9ezZ\nU9dee61GjBih3/72t7rsssty19122236+te/rizL9NWvflVXX321PvnJT2rKlCm68MILCwa+efNm\nfeMb39DZZ5+tK664YkeHyjQj++yzjyTpnXfe0bZt2/SlL31Jt9xyi2pqajRx4kRdeumlatOmjSZO\nnKjvfve7Dd976qmnNHbsWK1evVrjxo3T9ddfr7PPPlsLFy7U6NGj9corrwTvN378+IYtr/Hjx2vy\n5Mlq37594bqTTz5ZWZbpV7/6VeGzBx54QFmWNWwjr1u3TmeddZbuueceDRs2TJMmTdIFF1ygpUuX\navTo0Xrsscd2eJxMZVq3bq2rrrpKdXV1uuWWW6LX33DDDbryyivVoUMHTZw4UZdddpkOOOAATZo0\nSVdddVXu2n/913/Vz372M/Xq1UsTJ07UMccco0suuUSPPvpood677rpLEyZM0LvvvqvLL79c1113\nnQYNGqT//u//1nnnndfwrvrQ22G2h3HDDTdkpVIpmzZtWpZlWbZ+/fqsd+/e2cCBA7MtW7Y0XPf4\n449npVIpq66uzhYvXpyr45xzzslKpVL25z//OcuyLKuvr8+OPPLIbMyYMdm2bdsarlu+fHlWXV2d\nnX/++VmWZdmqVasa6ly0aFGuzvPPPz8rlUrZK6+8kmVZltXV1WXdu3fPhg8fnmtXlmXZtddem5VK\npWzOnDkNfyvXO3v27B0dIrOD3H333VmpVMpuv/324OcbN27MjjnmmKxXr17Zxo0bszlz5mSlUim7\n6qqrctdt3bo1GzlyZHbEEUdkdXV1WZZl2XXXXZeVSqVsyZIluWufe+65bOzYsdn8+fOzLPubrV1+\n+eUN19x8881ZqVTKHn/88Ya/8br6+vqse/fu2ZgxYwrtPvPMM7MePXpka9euzbIsy66//vqspqam\n8HzU1dVlffv2zUaMGJE0XqbplG2sPJfjx4/Punfvni1btix33T/90z81zOVzzz2XlUql7Nprry3U\nN378+KxUKmXPPvtslmVZ9oc//CErlUrZ6NGjc9ctXLgwq66uzkqlUnb33Xc3/P3GG2/MRo0ala1f\nvz53/YQJE7JSqZQtXLiw4W8fZjvco35hlg/7VFVVadiwYZKktm3b6oQTTtAbb7yhX//614Xv9OnT\nR7179879rWfPnpKk1157TZL0q1/9Slu3btXIkSPVokWLhuu6du2qX/ziF/r3f//33Pd79Oihvn37\n5v5WXV2dq3Pu3Ll655139PnPf16tW7fOXfv5z39ekjRv3rzc3/fee+/cIROze9myZYvefPPNhn+v\nv/66Fi5cqC996Utas2aNvvjFL6qqqqrhf9FnnXVW7vstW7bUKaeconfffVcLFixo+JskPfnkk7lr\na2pq9OMf/1jHHnvsDrV5//3311FHHaUnn3xS9fX1DX+vq6vT4sWLNXjwYH30ox+V9N4WXLdu3dSl\nS5dcP6uqqtSvXz8tW7ZM69at26H2mDSuuOIKtW7dWt/4xjeUbSeB1P333y9JOumkk3Lz9eabb+rE\nE0+U9N52v/SeJCVJw4cPz9XRr18/9enTp1D3ZZddpp///Odq27attm3bpvXr1+vNN9/UIYccIkl6\n+eWXm9SfD6od7lGnZMuHfUaOHKm2bds2/P20007T7NmzNW3aNJ100km575QnvDFt2rSR9N52mqQG\nHapTp06Fa2trawt/69y5c+FvVVVVktTg4rJixQpJ0uGHH164tkuXLpKkl156Kff3/fffX/vuu2/h\nerN7uPXWW3XrrbcW/t6uXTtdfvnlOu+88yT9ba4PO+ywwrWc61GjRmn27Nn69re/rdmzZ+vYY4/V\noEGD1Ldv34bFdEcZPny4HnnkEf3617/WmWeeKam4DbZ+/Xq99tpreu2119S/f//t1vXqq682vNhM\n89GxY0d95Stf0Xe+8x3NmjVLp512WuGaF154QZI0ZsyY7dZT3tIvL3Chd1Xv3r0L/2HbsGGDbrvt\nNj300EOqq6treDeWeffdd5vWIX0w7XCPWjDLh30GDBiglStXNvy9Y8eO+vjHP67HH39cq1atyi18\n/HUXorzItWrVKqkdKdeVBfzyQtqYsv61adOm3N//4R/+Ien+Ztfwz//8z7n/oe+1115q166dunbt\nqr333rvh7xs3blSrVq2Ctsa57ty5s2bNmqU77rhDDz74oKZMmaIpU6aoffv2Gj9+vEaNGrXD7R4y\nZIjatGmjhx56KPei2m+//XTcccdJkt566y1J7/2yraSXf+ITn9jh9pg0zj33XM2aNUs33XSTPvOZ\nzxQWiPKc/dd//Zc+/vGPB+s44IADJP3N3sr215iPfOQjuXKWZbrooou0aNEiHX300Ro/frw6dOig\nvffeW//7v//7vr0QPoh2uMcsmCtWrGjYbpg4ceJ2r5sxY0bDKa5UyqL1+vXr338DQfmXYujkW9mY\nvUD+fdOpUycNHDgwet2+++6rrVu36u233y4smuX5bzzXHTt21JVXXqkrr7xSS5cu1bx58/Szn/1M\n1157rfbdd1+dcsopO9Tutm3b6rjjjtPcuXO1bt06bdq0SYsXL9YZZ5zR0L5ye7Zu3ZrUR9P8tGzZ\nUtdcc43GjBmj//zP/9Q3v/nN3OflOevUqZN69epVsa7yPG/ZsqXw2YYNG3LlJUuWaNGiRRowYIB+\n+MMfaq+9/qbU/fa3v31ffZE+mHa4x2iY5f/lnHHGGZo8eXLh33e+8x3tvffeuvvuuwvbCTHK/3sp\nb8025uGHH9Yvf/nLJre3vD3X2FWgTHlrpWvXrk2u1/z9UWmuy+5O3bp1C363pqZGF198se644w5J\n2mn+eCNGjNDWrVv1m9/8prANJr33K+PAAw/UypUrcxpTmb/+9a87pR2mafTv31+nnnqqpk+fXjid\nX7azp556qvC9t956K7c4HnjggZIUPHVNV41yxJ6BAwfmFktJWrhw4fvoxd/4oNnhHrFglg/7tG7d\nWpdccknOmbz875RTTtGQIUP0+uuv6ze/+U2T6h88eLBatWqle+65J+eIvmbNGn31q1/VjBkzmtzm\n448/Xq1atdLdd9+tt99+O/dZeWu5LNSbPZvyMfu77ror9/ey3bZp00aDBw+WJF144YW5Y/plypp8\nJQmh/DIL/WoggwcP1kc+8hEtWLBADz/8sD7xiU+oX79+uWuGDRumd955Rz/96U9zf1+3bp1OPfVU\njRs3Lnofs/O57LLL1LZtW11zzTU57bB80PEXv/hFIRzoTTfdpE996lMNvuDlsxflg0JlFi1aVFhw\nyztsPNgzc+bMBn2+8f0+zHa4R2zJPvjgg1q7dq1OO+007b///tu9bsyYMXrwwQc1ffp0nX/++cn1\nH3jggfryl7+syZMn67zzztPnPvc5bdy4UXfeeackFfwrUzjggAP0ta99TTfddJPOOeccjRgxQq1a\ntdJjjz2m++67TyeccELDPr7ZsxkyZIiOO+44TZ8+XVu2bNHAgQP11ltvac6cOVqxYoWuvPJKfexj\nH5P0nv5etolhw4bpox/9qP7yl79o2rRpatmyZeGkbWPKYcimTJmi5cuX69hjj204wEZat26tz372\ns5o7d642bNigCy64IHcCXJIuvvhiPfzww7r99ttVX1+v/v37q76+XnfddZfq6+t1zjnn7KQRMk2h\nffv2+trXvtawJVs+uFhTU6Nzzz1XP/nJTzRq1CideeaZatmyZUOkoJEjRzZcO3DgQPXo0UMLFizQ\npZdeqkGDBunll1/WtGnTdPLJJ+vee+9tuF9tba0OOugg3XvvvTrwwAPVpUsXPfHEE3rsscd0zTXX\n6JJLLtGsWbP0sY99TMOGDftQ2+EesWA2juxTiQEDBqhUKumRRx4pnJaN8eUvf1kHHXSQ7rzzTn3z\nm9/UXnvtpb59++rmm29WTU3N+2r3uHHjdNBBB+knP/mJ/uM//kPvvvuuOnfurK9//esaO3bs+6rT\n/P3RokUL3XLLLfrhD3+oe++9V/fff79at26t7t2767bbbsu5Co0bN04dOnTQ1KlTdfPNN2vDhg3a\nb7/99MlPflKTJk0KHvkvM3ToUN1///169NFHtWLFCvXs2VMdO3bc7vXDhw9viOYSinnbrl07TZs2\nTbfddpvmzZune+65R1VVVerdu7cmTZqkAQMG7MComB1h1KhRmjlzpv7whz/k/n7FFVfo8MMP19Sp\nU/Xtb39b27Zt06GHHlp4p7Ro0UJTpkzR9ddfr/nz52vevHnq0aOHbr311gaXk/IvxTZt2uj222/X\npEmT9NOf/lT77LOPjjrqKP3P//yPOnTooHvvvVePPvqopkyZomHDhn2o7bBFtj2nH2OMMR84brjh\nBv34xz/WD37wgwapwKSxR2iYxhhj0tm8ebMuvfTSQtCVLVu26IEHHlCrVq0aAriYdPaILVljjDHp\nlP0vZ86cqXXr1mnIkCHavHmzZsyYoVdffVXjxo2reB7EhPGWrDHGfADZunWrfvSjH2n27Nl69dVX\ntW3bNnXt2lWnn366zj777MLhGxPHC6YxxhiTgDVMY4wxJoGKGmbZ36YMA/kedNBBufLvf//7XLlx\nvNcy9NfhcWQGHy/HRtxeuezfVuaNN96oWA7BfrHMNrNORhbab7/9Kpalv8VQ3N49GDaPdTRO6hr6\nnH0IRczgPdgPtmlHM2mkwiDMDEpeDmheJiW2L+2qQ4cOuTKdsBsH95eK8Tdpd7ye7gCSClFUPvOZ\nz1RocTHgNeecSdNJ9+7dC3+LBbBmVohy9p0yTJLOcd1eRKPGcOyOOuqoXJnh2I4++uhonTsK3dD4\nbDB2a+MAJ9uDdslkC8wjyWf4ueeey5UZZpPv31AYO0bPYYKAdu3a5coMKsDkEXwOnnnmmVw5FKmK\nY8X5Joy4Rq21R48eufL24uo2Jvb8lrMJlfn+978frMe/MI0xxpgEvGAaY4wxCVTckuXPc24ZcBuL\nW2cpOdRiW4msk59zG5HbwNzGkopBz9kPbn1wa5L3ZLlx6idJev311wtt4FYWY4hyy4BtZJti2xKh\nI+Sx7bRQu3cF3DakjTCOJsshYtu23N4i3E5lmXa2du3aQh20i1WrVuXK3EItB8Uuwy29v/zlL7ky\nbSCUKacclLsMx45jz8wWtBHa0KuvvporcytMKs4Ftw05TrsCjgvHjmX2IZTpiM8cZQBuyRK+Azgu\n3LoM+VWynS+++GKuzH6tWbMmV+7du3euTJtkXFpu4UvFdYD94NjFbKq6ujpX5pZvyO55Tz4rqenD\n/AvTGGOMScALpjHGGJOAF0xjjDEmgYoaJnUy7g1TV6PrQii3H11V6CbC/W62IaRJNob7/iGXDmo/\nvIYuH9Qo2W/uj9PtJJT6hsfWqaHx89g9OG7sA8dZKvaDbkGhsdsVUMMgmzZtypWp01ArCl1D3YTj\ny+s5P7QJaoE8ri8VXU+oYfH5osbJcaFmxc9D48hnlFosNUdqO3Q7oX7E5y+UzJ3PA9uUcvZhZ8N2\nl0qlXJl6Puc7pJFzPmOaJOeL7lVLly7Nlcs5L8uEXIaYQJrPPN+FfD+H9MDG8FkL6c90RWJi7E6d\nOlWsk64ttHvmlg250FF75VilJqr2L0xjjDEmAS+YxhhjTAJeMI0xxpgEKmqY1Mm4B0/od0QdTiru\n0zdVDyTU2ah/hPQQfof94ndi96CuQ40mpB/ynvwOx4HjxDbEwtqFxpHXsLw7tCSpqPXRF5CfsxzS\nXqmns2/U4uinRX9gton+Z9QGpaI2Qx2FdkRdLKZRpswftTf2k7oqczNQL6I2FHuepaJOmvKd5iYW\nDpO+gHV1dblyyBeYvp3sJ22Gdkybo08kx5FaoFTU3n/3u9/lyi+88EKuHHpnN+aPf/xjrpziA027\np91WVVXlyoccckiuzHWFujptMnRmhM8S2x16R4fwL0xjjDEmAS+YxhhjTAJeMI0xxpgEKmqY3GuO\nxZLl9SEdh/oE/QVZ5p56zLeJbQj5EcU0zJgGSZ+dffbZJ1em9hDS1NjOWBxefh7z6aKmGdKzYjFv\nU/f1dzbUF2hHnB9qOZwPqaiDULNkmfMT88WlnYVi+7JO6qAxzTIWz5ZQ2wndg2U+b9RVWWa/U+yO\n8UypccV0tOaAfrm0B/orUstL0V2paXL+OVa0Y55DoD4Zsjn2izrpsGHDcmXGkl2xYkWuTJ2Uvtsh\nf0a+u2IaJeMVM8YytX/aeSguNH1YOb8paekk/8I0xhhjkvCCaYwxxiTgBdMYY4xJwAumMcYYk0DF\nQz8UoXkoJBaYl2JvqE7CQwM8MMPPGYw9xdmeh0bYzljAd15PwZ9O8iFH2tDfKtUZO/TDflN8DwWt\n56GSjh075sqxoBHNRSzJMR2dY8HapaKt8mAADwHwsAQPFsQOJoUSCrMNPOzAe9D2eUAnFrw75FTO\nfvKePNTDgyexYAusL3QwiQemaJuc/10B+xl7t/HADm1SKgbg59jFDo6xTTy4wvpCB4/mzZtX+Ftj\n+vXrlyszKTUPNzEhAN9LtK/QNWw3AxHw81jydxJ6Hxx66KG5Mucv9j4u41+YxhhjTAJeMI0xxpgE\nvGAaY4wxCVTUMGPOuAwyENNUQnDf/u233674OaHORt0ntDcdS/5LYvvbsaDXoSS6hGPJOunMzbHl\nuFE3CM1FTO9N3dff2cSSPRP2NaSdxxL+UmujFkc75PepiaTYPtvE79DJnJpXTBvi9yXp5ZdfrtgG\n1hkL6s970qZCzy/r4NjvDu08FqCBbWRQDwapl4qJk9euXZsr85nl2Qd+nzY5d+7cXLmmpqbQBsIg\n8lOnTs2VOf/UNDk3Xbp0yZVDGiY1aWqWDDwSS8BBm+L3Q/DZigV03x7+hWmMMcYk4AXTGGOMScAL\npjHGGJNARQ2TWgM1lJjGxeul4t4x/QVjmkkssHksqLlU1HF4zyOOOKLwnUr3DPk4xqAuFwtazXEL\n9asSKdfTt3N3BV+P+ZCynTGdWypqddSEYwlmY/egdhN6NqhBUffk59QgeQ+2OaQfxdrJoOLUg2IB\n3mP1h54N2iLHNkX/3dnEAtszYDjnjnqkFPcZX758ea5MPZj6YIsWLXLlTZs25cqhMycMyM75YRJr\nzk3//v1z5Zhf55FHHln4G+2Y7WS/Ce0jpv2H6uPzzvlKeXYk/8I0xhhjkvCCaYwxxiTgBdMYY4xJ\noKKwxT12apLcF+bedEjHYR3UbeiLFEvuzDL1Rca/lYraAvsR00nZz1CC6MaEtNyYpkgNMxZ3kp/H\nEh5LxXZzX5/+T127dq3Q4p0H9aGYnsixCiVOJjEdhP5q1DholxzfkO8o66QGyUTK7CfbwFij1N04\njlJRsyJsE/UgtonvCI59yL+N/aDG1dTYoTsDjiXPDNDGqGlSCw79jTZGfZHj0Lt371yZyZ15FiOU\nOJ2xYjn2Tz/9dK5Mu2Us2aFDh+bK9FcN2RfjuPKMAuM6x/zaaWN8H4f8j9lv6r+h92MI/8I0xhhj\nEvCCaYwxxiTgBdMYY4xJoEnOfDHfQe6hhzRM7kczhmpMsyRsAzUW6pOhv/EezAsZyz1JbYqENM5Y\n3s9Ymd/nOMZ02BSa6uu5s+AcUrOgTsL5CWmYsb7QtqnN0EaoiTAfYsgnjnbCGJucU7aBGhjtkJpl\nyIeSdVBnY784F+wDP2e/Q/6r1GpJil/tzoZ6IseFNhbzF5eKNkc/TN6T/t+HH354rswzBinaHccy\n9j5l/NpFixblynxOaMMhLZA2E/OjjuWu5ecxnV0qvjP47PAe28O/MI0xxpgEvGAaY4wxCXjBNMYY\nYxJoUixZ6mTUbUhoP5v+b7Ecf/QF5L4/96LZ5pR4qIyfGfO75D2pd7AN9OmS0vJVNobjxOupy/J6\n6gahdtLPcvXq1RXb1FxQk4jpD7QJan9ScTxoyyQWR5n6IG0opKPQv5D9oD7EMwFsA58Nareh+Jix\nvKCxeLeEdsi5CumVbHcsF+muIGbrHMuUHLe0CT6jfDexTD2RpMQS5vzQxugnW19fX/FzapZsQ8jv\nlnYeix0bi3fL9xTfbaEzJbQ5+obSp7W6ujrYNv/CNMYYYxLwgmmMMcYk4AXTGGOMSaCihrly5cpc\nmdpeLN5iSEuiPhHLZ0ktKeajxf3s9u3bF67hHjr1C+53U2+kpsky+x3SgWL9ivldxmIfxjQ6qRgP\nk/pGKB7qruCll17KlWM+q2wn7VAqziFjSdJu+DnnkJ+TkA5HTZJzHtMT+Wzwc45DKBclNcxYPFrq\ncDEtnb6A1Iakop8z3yOh90Zzw3FgDGqWY7GFQ9fwHu3atcuVGbeV7ymONe2H+qJUfBY4n2zT8OHD\nc2X2OxZrmDk7peK7iG1gv6h789nj90no2eM5E74PUnP/+hemMcYYk4AXTGOMMSYBL5jGGGNMAhU1\nTO7LUzuiX1GKbxL3s5n/knUydxr35KmHEMZflIqaJbUA7qlTo6TGSV2H+/qhPHUk5icY87NkmfpV\nSPOMxcN8P/FndwbUfjjn1OGogfFzqehfxvHg54SaB3U23pO+oVJxTrIsy5Vpd+wX9aOY/2JIy6XG\nSNukrfMetAmOC+eOz4pU1DV5z5jvZ3PAvJ7z58/PlTlOsbmSirFgU+OVbu/6AQMG5MoLFizIlZkv\nUyq+H6mTci7YL84f7b62tjZXDr3raLd8/zLvJ9vAOvl+TfE/JkuWLMmV6ZdpP0xjjDFmB/CCaYwx\nxiTgBdMYY4xJwAumMcYYk0DFQz8UnXkQJXbIJ3RoJHaQJHZ4hc7ZseTOocMuPORz8MEH58qxYOsc\nh+7du+fKHBfWL8WDrROOQyw4OA9jhIIQsF9s0+469MPDC3V1dblyv379cmUGWw6NLQ8r0AZoRyzz\n8AsPQ/BwRSiBdCzZeezwQsg5vjE8eBRy8Oacx8Yh9jzyEFHsYFLob2zD7giY8corr+TK7DeDafAg\nCt8BUtGOeViFc8HA5d26dcuVaVMMPBIK6sJ28kAVn53YoUzaB4MlMEBAqA6W+SzxHrF3GftIG5SK\nNsfnNXRIL4R/YRpjjDEJeME0xhhjEvCCaYwxxiRQUcOMJVKO6Wh0tg8R0+boEBxztmd9IZ2V32G/\nqDmyX7GE0yQ0DrF+EN6DegX3+VkOjQP7zbEOBe/eFVCDYMJY6hGh4BQxqB8xSS21npAu0pgUW+f4\n0s5oA7wntR5+HtPzpaL+EwsaQB2Vdkedjm0KObJTq6PuFQuu3RzU1NTkygyMfs899+TKsXefFE8A\nTa192LBhuTLHmho19cOQhvnUU0/lypyvxYsX58oMtsBxIZzLUHLoZ599Nldm4gLaJM8bxAIVsE+h\nwAV8/zFQQZ8+fQrfCeFfmMYYY0wCXjCNMcaYBLxgGmOMMQlU1DDpk0ONhLoNrw8FXqauEkuMTB2N\ne8+xxJ8h7Y76HrUB6joxn0nqi0y6GtI3YpoX20ioV/AeMS1YKs5n586dc2X2Y1cxcODAXJnBmqk3\nsm9MQCvFA5Xzc9oEkwDQR5k2ErIZ2j59v+jTyOeHWh81LM556Pljv6k5hnTPxlAfiiVP79KlS6EO\njg19AUM+rM0NfQM5NyeffHKAj/pAAAAO5klEQVSuzCDmzzzzTKHOmPZGrZbz+8ILL1S8nnN3wgkn\nFNrAZ/yxxx7Llamjs8x78tlbunRprhzyw2SAd+qktNOmJgQgoXcrnw361VKr3d65FP/CNMYYYxLw\ngmmMMcYk4AXTGGOMSaBJfpj0d4slkw3tA8c0ylgd1Nnej+8gNRRqR7E2xOJtck8+pKOyndynZxti\ncV95D+rJIV2IegXvuXLlyly5VCoV6mgOqDewndQXqeeG/NEYd5O6CueUdTTV1zPkj8bxZb+o5dGP\nj9pOLCZrSI/kd6g58lmgZsnP6bdJzSvkX0y/u1jC4F0BbYr9pL8hx5HXS3Hf3pCNNIa+oNOnT8+V\njznmmFx5zpw5hTqoc/MMCJ9pzhfPAyxbtixXpn9q6D0TS0pNG6M2y3FiG1k/bTqlTj571jCNMcaY\nHcALpjHGGJOAF0xjjDEmgYoaJv3f6N9CXyXqiyH/Q2p3sZiozFsW8xtKiQHKdvE79LnjvnwsXyY/\nT8nJyT1zficWezbmgxfyTaJuw7mJ+bg2F0cffXSuTJ8panvUk0IaGOeY48X54BxSo6JGHPLDI9SP\nqL3wc9oV9SZ+n+PCPKJSUT8M2WZjYnkC309uS+qcMX/UXUEs3ymfFY59aBxjeRyptdGHkW3i/M6f\nPz9XHjx4cKEN9P2M6cPULPn+ZB94NmD58uWFOtkP9pN+mRxrjtM//uM/5sopsYf5DmH+UvqcV1dX\nB+vxL0xjjDEmAS+YxhhjTAJeMI0xxpgEKmqYn/70p3PlmP9LLA6lFPdxpDbEz2NxXQ877LBcOeSX\nSW2W7aaPHnUZ+uzF4r6G9A3+LTaW9DelzkpdgG0OjQM1kZhuuqtgX6knUX+g3hjS3ehHSW2Gugk/\np1bDOWcbQ75gtBvOOeewW7duuTK1PV4f89WVinNOO6HeRH+1mL9qzD9YiufYpE/croDa3u9///tc\nOeYrGIpfzOeJeRtpk3/6059yZeqPtGvqifTblIrvU0J7YPxa+nHSzjnf9FeVivMZ85vmXNAGeR6B\n/Q49e+wnn/dY3s8y/oVpjDHGJOAF0xhjjEnAC6YxxhiTQEXxjToN/SwJ/b5C+fi4p848dLFceDG9\nMKaBSkWfRPrgxHJ0huJjNob7+qE+UQuK+VWyjSzHYtOG2hDLdxnTi5uL9u3b58rUJKgfLV68OFcO\n6bWbNm3KlakPUf+jbkL9iDoLdZRQzj7qYIQa5fPPP1+xTdSGYrFJpeLY0dZjPpIxf8RYnGap+Dxx\nLHdHLFmONcehqqoqV+a7LqSb06bo28e4rKtWrcqV+Q7gc8D5DvlAUlPk2NImOb/UXamb8jnicyYV\n33V8PtmPmA1R8+R5jtDzz/lZsmRJrsz8ttvDvzCNMcaYBLxgGmOMMQl4wTTGGGMSqCgIxnQ25kvk\nvn5KfEXqibF8ltyn5/cZbzOUxzCWkzPmb8o8d9TcuM8finVIbZV6RyzGZyzmLrWpkPbLWLEp39kV\ncHypu1HLoYbB70tFrYVwPng9dRPqLtR6Qvp9DOo/9DejjdCu2GbqUVLT813GNMqYH2YoNyn1Xdou\n/Ut3BbHYovX19bnykUcemSuHnhXqYrGYqrQZ6o28J999KTbHNvHZYj/5PmWb6N8Y0ulj2j0/pw3F\ntHo+J6G54PP9qU99KlfmO3x7+BemMcYYk4AXTGOMMSYBL5jGGGNMAl4wjTHGmAQqnuqIOcczSADL\nIfE1dqCG4iwPLvAQD+vjAZAQsWDqPAzDwxaxfseSE4fgPZoaHIHEAhmE4EGjWGCD5oIHEWIO4Dw8\nkZLMmQeHWObhBtoID1jEAopLxcMJPGDBOthvzmksmW8Itiv2PLHMg0axQNohO6UTeVMPvDUHtDm+\nuxgAICW5OuvkWDKwOe2B78KYDfL7ITh/PIgUC2TAueEhzNjhOqloE7wnn2f2m4eA2KauXbsW7smD\nQjxgl5powr8wjTHGmAS8YBpjjDEJeME0xhhjEqioYVKPoKZF7YHXhxz2SSxQOZMJx0hJYs1A2Z06\ndarYJiaUpk5KLYF77iGoZzQ1eTO/n9JvQu01lrR6V0EdhNpMTIMOaXkvvvhirhwLIh4LfE3th20K\nBR1nHUuXLs2VY9ot9SI6W6foR3Q05zNKrYefx+yO5ZB2HhvLmKN7c8B2sp98VqijhbRavicYNICf\nc+z5/HGcYknQpeI7+7DDDsuVmfyC881x4dzQ5kJJB2IBUVhnyjmUxrDfIS2X88nnk8/WcccdF7yX\nf2EaY4wxCXjBNMYYYxLwgmmMMcYkUFHDjPkaxXS3kC8a9/r5nVR/mDLcD+eee8gXlPvX/A41SbYp\npuMwKHJK8mZ+h7ocx436Bn302O/QOHB+WEco+fauIBZ8mzoJNQzqdFLR74q+gPSJi2l51OFiGphU\nbDevoR7EMjVL2gx1NfoOSvEk07HkzbQZ+oKm+FDGEgKHdLDmhroZfWZj/oghmASAdk2b7NChQ8Uy\ntT6OU0hH5XPP+T344INzZeqinJtu3brlypx/jptUTM7NOvns8f0bC+jP7zPZtyTV1NTkyhyHmF97\nGf/CNMYYYxLwgmmMMcYk4AXTGGOMSaCihtm5c+dcmToO9+Sp46T4Bsb8uGK+gdx7pl8R9+RD3+E+\nfExHjSXBJiEtN5a0mhoJ9cSYZkb9OZSYm3Xwnin+pM0B54xaDW2C80V9UipqFkxazLFgjFXqRxyb\nkJ2R2DUxn+SYtvt+/J5j8U5j+iLtihpWSAen/svE8yEf1uaG+m/MF5DvAL5DpLg/Kefi0EMPzZXp\nT0x/cJbZByn+XiD0R4yNC8t8/6ZAzZI2xjppUymxiDlWPA8QemeE8C9MY4wxJgEvmMYYY0wCXjCN\nMcaYBCpqmNwLpqbJz2O+gClwv5p18POYL1tIuyPcE4+1m3VyHFJ8tGL9oH4Vu2fs+yGoT3EcqC3s\nKqiLUAuK6bchH0jqRdT7YrpoLG4yfcFC+lVM04rF6WQsUvoGUj+kVhi6pnv37hXbwHGL3YPfD81F\nLGbu7vDDZL/oI0nfPvY75MfH+eN3qFlyflknfSA5js8++2yhDbFYsNTi6acbi+3NNjPmbgi2M+ZP\nynclr+f5hJDN0ae1S5cuuXLKGQTJvzCNMcaYJLxgGmOMMQl4wTTGGGMSqCjWxWKJUnvg9SlxYanF\nxXw36fPI/Wz6Q4V8IHlP7uvTDyyWz41aH/fQQ/pGzF8p1O5KxGLohnTV2D12VyzZmO5CG6FuEtIj\nWEcsBibroJ9WLFdoyI453rH4pNSTWGcsxmZoHGJxlKmzsRyLRUtCeiTHms9Lqk/cziTmV0sf2JTY\no9TNWCc/Z7/pK8zYtIwVTI1TkpYtW5Yr0+ZYJ+2B9sJ+sw2sTyrm4KSPM99VHBee36BuyjZSG5aK\ndst3Osd6e/gXpjHGGJOAF0xjjDEmAS+YxhhjTAIVNUxqQ3/84x/zX8beM7WIUGxL6jCMI8l7Ulvg\n3jO1QO6Ph4jFDWX8xFj+yxghrZB1xGLL8nqOC/vEe4Y0zFi82qbmJm0uqP3Qv42EPqdfHcebGmen\nTp1yZWogbBO/H8oLSDvjNRxv3oNaDT/n8xaKLcpraEeMuRmLbxvz9w3NRczvLpaTszmIxU1+6aWX\ncmVqgSltPvzww3Nl6uC0Ib4bGef16aefzpVffPHFwj2pvTI3JWPLsl98TthPjhu/LxV1zdg5lNCz\n0xiOG9vwyiuvFL7DZ4tjyXWnuro6eG//wjTGGGMS8IJpjDHGJOAF0xhjjEmgooZJ/8JY/NIUvz3u\nFcf8Bwk1S+6pM88ZtasQTc2HGcu/lhJLlvv43IdnHbw+lj+ThHTXWMzGlH40B9Q0qB/G5iukgVDT\npR5I2+V8xPzuYrFmQ3+jZkXbp0YZs7OQfkRYJ/WlWBs5F7F4xKG4ntTVdvSMQHPAcaK/IW00pqtL\nRTuljytjKLMN1Cw59iE9mfNFm+H7sr6+vlBHJfishbRc1llTU5MrU2tnv3r27Jkrs830ywxp97yG\nNsj4ttYwjTHGmB3AC6YxxhiTgBdMY4wxJgEvmMYYY0wCFU/YxBJCU0DmgR4eVJGKgj6FatZBx1oK\nvryen4cOrqxevTpXfuaZZyq2KXYghGI+HdRLpVKhDayT94wlb445kMeSLIdYuXJlrhwLEN9c8AAF\n287DLTzAE4KHdmIB85lglnbE+hg4O3Toh9/hoQ8eUGObeIBjzZo1uTIP6DCptVQMyMB78jBE7NAP\nD8PEAmhIxbFnsOymBnjfGcQSJXN+eSDn9ddfL9QZOwTJseV80uZo5127ds2VQ++MqVOn5so8MMfE\n2DwcQxtt0aJFxfpCh5+yLMuVY4e6YgeoOPacq9DBI84Pg60zSMT28C9MY4wxJgEvmMYYY0wCXjCN\nMcaYBCpqmNxrTtHBGpOStJj3oGYZCyLA+qizhrQF9oNaLaG+QQ2TWi37EArszGsItQMSS7xNzSUU\nEIL9ZgLamI7aXNCBO6b9MWB4yGaooxDaSSxhMO2OOlwoeTMdqqm9HHLIIbky55Bt4JxzXEJJrqnv\n0Kk8Zkd8FmJJr6lxSUUNmmO5dOnSXLl79+6FOnY27Df1X9oDCen9tAGWqZtxLjifDN7O5zekw8W0\nVwbjjwUNIZy7kP5ILZffiQUVoc1yXPh9nmuRiu9ojkNKgBvJvzCNMcaYJLxgGmOMMQl4wTTGGGMS\nqKhhzp07N1ceNGhQrkw/IO4DhzRMaiCxQOa8nlpT7PqQfkhtjvv89Eck1IaoiaYEk6b+wHZz3566\nT0xfTgkoz36yjp///Oe58tixYwt1NAdPPPFErhzTgqg3hbTXWKBq6iz0kaOGRb2RhDRM+rjxHrTV\nWEB+6kUdOnSoeH3oO7wH7SYW4J16E8shbS+mSS9YsCBXPu200wp17GyoH1LbiwWdTwm+Tn2Quhp9\nIqnlxxJPcP6l4nzyXcf5ZB2xBOJ8H4e0QL7rqEnzWeE9+JwwYQD7FNJdWQd1zjlz5uTKn/3sZwt1\nSP6FaYwxxiThBdMYY4xJwAumMcYYk0CLLOagZowxxhj/wjTGGGNS8IJpjDHGJOAF0xhjjEnAC6Yx\nxhiTgBdMY4wxJgEvmMYYY0wC/w/SMs4jl8V0hAAAAABJRU5ErkJggg==\n",
+            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAcwAAACmCAYAAABXw78OAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4zLCBo\ndHRwOi8vbWF0cGxvdGxpYi5vcmcvIxREBQAAIABJREFUeJztnXu4VlWdx78oF4+RkSTiJCKg7zki\nlw7XJBXHSEEBzXQUIUUlzSaeQksbxUtJpjkzPXhpsB6nKZuSiyA5eCshsdQEjTATUkAC9aCdBEEE\nUfb84fOezv7sxbvWAQ6Efj/Pc/5Y77v22uvy23udd33X77daZFmWyRhjjDEV2Wt3V8AYY4zZE/CE\naYwxxiTgCdMYY4xJwBOmMcYYk4AnTGOMMSYBT5jGGGNMAp4wm8Dq1atVXV2tq6++endXxbzPKdva\nN77xjZ2Sz5jm5INih3vshHnjjTequrpa/fr106ZNm3Z3dcz7iJkzZ6q6urrwd8QRR2jQoEH613/9\nVy1cuLBZ69C+fXtNnjxZo0ePzn3+/e9/X6tXr47mM//YlG2sV69eWrVq1TbzHX/88fr85z+/C2uW\nxgfVDlvu7gpsD2+//bZmzZqlvfbaS+vXr9cDDzygU089dXdXy7zPGDFihIYMGdKQ3rRpk5YvX66p\nU6dq7ty5uvHGGzVy5MhmuXdVVZWGDh2a+2zVqlWaPHmy+vbtq4MPPnib+cyew+bNm3XdddfpBz/4\nwe6uSjIfZDvcI39hPvTQQ3r99dd11llnqUWLFpo2bdrurpJ5H1IqlTR06NCGv1NPPVWXXHKJZsyY\noaqqKn3729/Wli1bdll9nnnmmV12L7NrGDhwoB555BE99NBDu7sqyXyQ7XCPnDCnTp0qSTr33HPV\nt29fPfXUU1q2bFkuz+9+9ztVV1fr+9//vp566imNHj1atbW1qq2t1bhx44LLIPfdd5/OOuushnwX\nXXSRnn322WAdnn/+eZ1//vnq06ePamtrdcEFF+gvf/lLId8vfvGLhjJ79uypoUOH6nvf+542btyY\ny1ddXa2xY8fq0Ucf1YknnqhPfepT29s9ppnp1KmTBgwYoLVr1+r555+X9N4vhVtvvVUnnXSSevXq\npdraWp1xxhmaPn164fonn3xSF154oY455hj17NlTxx57rCZMmKA///nPDXmoCX3+85/XhAkTJEnn\nnHOOqqurtXr16kK+s88+WzU1NVqzZk3hvnV1daqpqcktm/3tb3/TpEmTdPzxx6tHjx4aOHCgLr74\nYv3hD3/YeR1mtskXvvAFde7cWd/+9rcL74RtMWPGDJ1++unq3bu3amtr9dnPflZ33nmntm7dmsu3\nYcMGXXfddTr66KPVq1cvnX766frtb3+r6dOnq7q6WjNnzszlv++++zR69Gj16dNHPXv21Iknnqgb\nb7xRb7zxRkOeD7od7nET5ooVK/Tkk0+qtrZWhx56aMNSbOjFJElLly7Vl7/8ZfXv319XX321Tj75\nZD366KMaP358Lt8dd9yhCRMmqF27drrmmms0YcIEPf/88xo1apQWL16cy1tfX6+LLrpIPXv21LXX\nXqsRI0boN7/5jS677LJcvttuu01f//rXlWWZvvKVr+jqq6/WJz7xCU2ZMkUXXnhhwcA3bdqkb37z\nmzr77LN1xRVX7GhXmWZkn332kSS988472rp1q774xS/qlltuUU1NjSZOnKhLL71Ubdq00cSJE/W9\n732v4bqnn35aY8eO1erVqzVu3Dhdf/31Ovvss7VgwQKNHj1aL7/8cvB+48ePb1jyGj9+vCZPnqz2\n7dsX8p188snKsky//OUvC9898MADyrKsYRl53bp1Ouuss3TPPfdo2LBhmjRpki644AItWbJEo0eP\n1uOPP77D/WQq07p1a1111VWqq6vTLbfcEs1/ww036Morr1SHDh00ceJEXXbZZTrggAM0adIkXXXV\nVbm8X/va1/TTn/5UvXr10sSJE3XMMcfokksu0WOPPVYo96677tKECRP07rvv6vLLL9d1112nQYMG\n6X/+53903nnnNbyrPvB2mO1h3HDDDVmpVMqmTZuWZVmWrV+/Puvdu3c2cODAbPPmzQ35nnjiiaxU\nKmXV1dXZokWLcmWcc845WalUyv7yl79kWZZl9fX12ZFHHpmNGTMm27p1a0O+ZcuWZdXV1dn555+f\nZVmWrVq1qqHMhQsX5so8//zzs1KplL388stZlmVZXV1d1r1792z48OG5emVZll177bVZqVTK5syZ\n0/BZudzZs2fvaBeZHeTuu+/OSqVSdvvttwe/37hxY3bMMcdkvXr1yjZu3JjNmTMnK5VK2VVXXZXL\nt2XLlmzkyJHZEUcckdXV1WVZlmXXXXddViqVssWLF+fyPvfcc9nYsWOzRx55JMuyv9va5Zdf3pDn\n5ptvzkqlUvbEE080fMZ89fX1Wffu3bMxY8YU6n3mmWdmPXr0yNauXZtlWZZdf/31WU1NTeH5qKur\ny/r27ZuNGDEiqb9M0ynbWHksx48fn3Xv3j1bunRpLt8///M/N4zlc889l5VKpezaa68tlDd+/Pis\nVCplzz77bJZlWfbHP/4xK5VK2ejRo3P5FixYkFVXV2elUim7++67Gz6/8cYbs1GjRmXr16/P5Z8w\nYUJWKpWyBQsWNHz2QbbDPeoXZnmzT1VVlYYNGyZJatu2rU444QS9/vrr+tWvflW4pk+fPurdu3fu\ns549e0qSXn31VUnSL3/5S23ZskUjR45UixYtGvJ17dpVP//5z/Vv//Zvuet79Oihvn375j6rrq7O\nlTl37ly98847+tznPqfWrVvn8n7uc5+TJM2bNy/3+d57753bZGJ2L5s3b9Ybb7zR8Pfaa69pwYIF\n+uIXv6g1a9boC1/4gqqqqhr+iz7rrLNy17ds2VKnnHKK3n33Xc2fP7/hM0l66qmncnlramr0ox/9\nSMcee+wO1Xn//ffXUUcdpaeeekr19fUNn9fV1WnRokUaPHiwPvKRj0h6bwmuW7du6tKlS66dVVVV\n6tevn5YuXap169btUH1MGldccYVat26tb37zm8q2cYDU/fffL0k66aSTcuP1xhtv6MQTT5T03nK/\n9J4kJUnDhw/PldGvXz/16dOnUPZll12mn/3sZ2rbtq22bt2q9evX64033tAhhxwiSXrppZea1J73\nqx3uUbtky5t9Ro4cqbZt2zZ8ftppp2n27NmaNm2aTjrppNw15QFvTJs2bSS9t5wmqUGH6tSpUyFv\nbW1t4bPOnTsXPquqqpKkBheX5cuXS5IOP/zwQt4uXbpIkl588cXc5/vvv7/23XffQn6ze7j11lt1\n6623Fj5v166dLr/8cp133nmS/j7Whx12WCEvx3rUqFGaPXu2vvOd72j27Nk69thjNWjQIPXt27dh\nMt1Rhg8frkcffVS/+tWvdOaZZ0oqLoOtX79er776ql599VX1799/m2W98sorDS8203x07NhRX/7y\nl/Xd735Xs2bN0mmnnVbI88ILL0iSxowZs81yykv65Qku9K7q3bt34R+2DRs26LbbbtNDDz2kurq6\nhndjmXfffbdpDdL70w73qAmzvNlnwIABWrlyZcPnHTt21Mc+9jE98cQTWrVqVW7i46+7EOVJrlWr\nVkn1SMlXFvDLE2ljyvrXW2+9lfv8Qx/6UNL9za7hX/7lX3L/oe+1115q166dunbtqr333rvh840b\nN6pVq1ZBW+NYd+7cWbNmzdIdd9yhBx98UFOmTNGUKVPUvn17jR8/XqNGjdrheg8ZMkRt2rTRQw89\nlHtR7bfffjruuOMkSW+++aak937ZVtLLP/7xj+9wfUwa5557rmbNmqWbbrpJn/70pwsTRHnM/vM/\n/1Mf+9jHgmUccMABkv5ub2X7a8yHP/zhXDrLMl100UVauHChjj76aI0fP14dOnTQ3nvvrf/7v//b\nbi+E96Md7jET5vLlyxuWGyZOnLjNfDNmzGjYxZVKWbRev3799lcQlH8phna+lY3ZE+Q/Np06ddLA\ngQOj+fbdd19t2bJFb7/9dmHSLI9/47Hu2LGjrrzySl155ZVasmSJ5s2bp5/+9Ke69tprte++++qU\nU07ZoXq3bdtWxx13nObOnat169bprbfe0qJFi3TGGWc01K9cny1btiS10TQ/LVu21DXXXKMxY8bo\nP/7jP/Stb30r9315zDp16qRevXpVLKs8zps3by58t2HDhlx68eLFWrhwoQYMGKAf/vCH2muvvyt1\nv/nNb7arLdL70w73GA2z/F/OGWecocmTJxf+vvvd72rvvffW3XffXVhOiFH+76W8NNuYhx9+WL/4\nxS+aXN/y8lxjV4Ey5aWVrl27Nrlc849HpbEuuzt169YteG1NTY0uvvhi3XHHHZK00/zxRowYoS1b\ntujXv/51YRlMeu9XxoEHHqiVK1fmNKYyf/vb33ZKPUzT6N+/v0499VRNnz69sDu/bGdPP/104bo3\n33wzNzkeeOCBkhTcdU1XjXLEnoEDB+YmS0lasGDBdrTi77zf7HCPmDDLm31at26tSy65JOdMXv47\n5ZRTNGTIEL322mv69a9/3aTyBw8erFatWumee+7JOaKvWbNGX/nKVzRjxowm1/n4449Xq1atdPfd\nd+vtt9/OfVdeWi4L9WbPprzN/q677sp9XrbbNm3aaPDgwZKkCy+8MLdNv0xZk68kIZRfZqFfDWTw\n4MH68Ic/rPnz5+vhhx/Wxz/+cfXr1y+XZ9iwYXrnnXf0k5/8JPf5unXrdOqpp2rcuHHR+5idz2WX\nXaa2bdvqmmuuyWmH5Y2OP//5zwvhQG+66SZ98pOfbPAFL++9KG8UKrNw4cLChFteYePGnpkzZzbo\n843v90G2wz1iSfbBBx/U2rVrddppp2n//fffZr4xY8bowQcf1PTp03X++ecnl3/ggQfqS1/6kiZP\nnqzzzjtPn/3sZ7Vx40bdeeedklTwr0zhgAMO0Fe/+lXddNNNOuecczRixAi1atVKjz/+uO677z6d\ncMIJDev4Zs9myJAhOu644zR9+nRt3rxZAwcO1Jtvvqk5c+Zo+fLluvLKK/XRj35U0nv6e9kmhg0b\npo985CP661//qmnTpqlly5aFnbaNKYchmzJlipYtW6Zjjz22YQMbad26tT7zmc9o7ty52rBhgy64\n4ILcDnBJuvjii/Xwww/r9ttvV319vfr376/6+nrdddddqq+v1znnnLOTesg0hfbt2+urX/1qw5Js\neeNiTU2Nzj33XP34xz/WqFGjdOaZZ6ply5YNkYJGjhzZkHfgwIHq0aOH5s+fr0svvVSDBg3SSy+9\npGnTpunkk0/Wvffe23C/2tpaHXTQQbr33nt14IEHqkuXLnryySf1+OOP65prrtEll1yiWbNm6aMf\n/aiGDRv2gbbDPWLCbBzZpxIDBgxQqVTSo48+WtgtG+NLX/qSDjroIN1555361re+pb322kt9+/bV\nzTffrJqamu2q97hx43TQQQfpxz/+sf793/9d7777rjp37qyvf/3rGjt27HaVaf7xaNGihW655Rb9\n8Ic/1L333qv7779frVu3Vvfu3XXbbbflXIXGjRunDh06aOrUqbr55pu1YcMG7bfffvrEJz6hSZMm\nBbf8lxk6dKjuv/9+PfbYY1q+fLl69uypjh07bjP/8OHDG6K5hGLetmvXTtOmTdNtt92mefPm6Z57\n7lFVVZV69+6tSZMmacCAATvQK2ZHGDVqlGbOnKk//vGPuc+vuOIKHX744Zo6daq+853vaOvWrTr0\n0EML75QWLVpoypQpuv766/XII49o3rx56tGjh2699dYGl5PyL8U2bdro9ttv16RJk/STn/xE++yz\nj4466ij97//+rzp06KB7771Xjz32mKZMmaJhw4Z9oO2wRbYtpx9jjDHvO2644Qb96Ec/0g9+8IMG\nqcCksUdomMYYY9LZtGmTLr300kLQlc2bN+uBBx5Qq1atGgK4mHT2iCVZY4wx6ZT9L2fOnKl169Zp\nyJAh2rRpk2bMmKFXXnlF48aNq7gfxITxkqwxxrwP2bJli/77v/9bs2fP1iuvvKKtW7eqa9euOv30\n03X22WcXNt+YOJ4wjTHGmASsYRpjjDEJVNQwy/42ZRjI96CDDsqlf//73+fSjeO9lqG/DrcjM/h4\nOTbittJl/7Yyr7/+esV0CLaLadaZZTKy0H777VcxLf09huK27sGweSyj8aGuoe/ZhlDEDN6D7WCd\ndvQkjVQYhJlBycsBzcukxPalXXXo0CGXphN24+D+UjH+Ju2O+ekOIKkQReXTn/50hRoXA15zzHlo\nOunevXvhs1gAa54KUT59pwwPSWe/biuiUWPYd0cddVQuzXBsRx99dLTMHYVuaHw2GLu1cYCTbUG7\n5GELPEeSz/Bzzz2XSzPMJt+/oTB2jJ7DAwLatWuXSzOoAA+P4HPwzDPP5NKhSFXsK443YcQ1aq09\nevTIpbcVV7cxsee3fJpQmf/6r/8KluNfmMYYY0wCnjCNMcaYBCouyfLnOZcMuIzFpbOUM9RiS4ks\nk99zGZHLwFzGkopBz9kOLn1waZL3ZLrx0U+S9NprrxXqwKUsxhDlkgHryDrFliVCW8hjy2mheu8K\nuGxIG2EcTaZDxJZtubxFuJzKNO1s7dq1hTJoF6tWrcqluYRaDopdhkt6f/3rX3Np2kDopJxyUO4y\n7Dv2PU+2oI3Qhl555ZVcmkthUnEsuGzIftoVsF/Yd0yzDaGTjvjMUQbgkizhO4D9wqXLkF8l67li\nxYpcmu1as2ZNLt27d+9cmjbJuLRcwpeK8wDbwb6L2VR1dXUuzSXfkN3znnxWUo8P8y9MY4wxJgFP\nmMYYY0wCnjCNMcaYBCpqmNTJuDZMXY2uC6Gz/eiqQjcRrnezDiFNsjFc9w+5dFD7YR66fFCjZLu5\nPk63k9DRN9y2Tg2N38fuwX5jG0IaHfPQLSjUd7sCahjkrbfeyqWp01ArCuWhbsL+ZX72H22CWiC3\n60tF1xNqWHy+qHGyX6hZ8ftQP/IZpRZLzZHaDt1OqB/x+Qsd5s7ngXVK2fuws2G9S6VSLk09n+Md\n0sg5njFNkuNF96olS5bk0uUzL8uEXIZ4gDTfXXwX8v0c0gMbw2ctpD/TFYkHY3fq1KlimXRtod3z\nbNmQCx21V/ZV6kHV/oVpjDHGJOAJ0xhjjEnAE6YxxhiTQEUNkzoZ1+AJ/Y6ow0nFdfqm6oGEOhv1\nj5AewmvYLl4Tuwd1HWo01GlD9+Q17Af2E+sQC2sX8qlkHqZ3h5YkFbU++gLye6ZD2iv1dLaNWhz9\ntOgPzDrR/4zaoFTUZqij0I6oi8U0ypTxo/bGdlJX5dkM1IuoDcWeZ6mok6Zc09zEwmHSF7Curi6X\nDvkC07eT7aTN0I5pc/SJZD8eeuihhTrQ5n7729/m0i+88EIuHXpnN+ZPf/pTLp3iA8060G6rqqpy\n6UMOOSSX5rxCXZ02GdozwmeJ9Q69o0P4F6YxxhiTgCdMY4wxJgFPmMYYY0wCFTVMrjXHYskyf0jH\noT5BX0CmuaYe821iHUJ+RDENM6ZB0mdnn332yaWpPYQ0NdYzFoeX38d8uqhphvSsWMzb1HX9nQ31\nBdoR+45aDsdDKuog1CyZ5j1ivri0s1BsX5ZJHTSmWcbi2RJqO6F7MM3njboq02x3it0xnik1rpiO\n1hzQL5f2QH9Fankpuis1TY4/+4p2zP0c9A0O7TFhu6iTDhs2LJdmLNnly5fn0vSZpO92yJ+R766Y\nRsl4xYyxTO2fdh7yOacPK8c35Vg6yb8wjTHGmCQ8YRpjjDEJeMI0xhhjEvCEaYwxxiRQcdMPRWhu\nCokF5qXYGyqTcNMAN8zwewZjT3G256Ye1jMW8J35KfjTST7kSBv6rFKZsU0/bDfF91DQem4q6dix\nYy4dCxrRXLAeDLZOR+dYsHapaKvcGMBNANwswY0FsY1JoQOFWQduduA9aPvcoBML3h1yKmc7eU9u\n6uHGk1iwBZYX2pjEDVO0TW6O2RWwnbF3Gzfs0CalYgB+9l1s4xjrxI0rLC+08WjevHmFzxrTr1+/\nXJqHUnNzEw8E4HuJ9hXKw3ozEAG/jx3+TkLvAwZ14PjF3sdl/AvTGGOMScATpjHGGJOAJ0xjjDEm\ngYoaZswZl0EGYppKCK7bv/322xW/J9TZqPuE6hA7/JfE1rdjQa9Dh+gS9iXLpDM328V+o24Q6oeY\n3pu6rr+zSdFFKuUPaeexA3+ptVGLox3yemoiKbbPOvEaOplT84ppQ7xekl566aWKdWCZsaD+vCdt\nKvT8sgz2/e7QzmMBGlhHBvVgkHqpeHDy2rVrc2k+s9z7wOtpk3Pnzs2la2pqCnUgDCI/derUXJrj\nT02TY9OlS5dcOvSsUpOmZsnAI7EDOGhTvD4En61YQPdt4V+YxhhjTAKeMI0xxpgEPGEaY4wxCVTU\nMKk1UEOJaVzMLxXXjukvGNNMYoHNY0HNpaKOw3seccQRhWsq3ZN+ZCmBmOmnFwtazX4LtasSKfnp\n27m7gq/HfEhZz5jOLRW1OmrCsQNmY/egdhN6NqhBUffk99QgeQ/WOab1hvIwqDj1oFiA91j5If9f\n2iL7NkX/3dnEAtszYDjHjnqkFPcZX7ZsWS5NPZj6YIsWLXJp+ieH3js8BIDvFR6EzbHp379/Lh3z\n6zzyyCMLn9GOWU+2m9A+Ytp/qDw+7xyvlGdH8i9MY4wxJglPmMYYY0wCnjCNMcaYBCoKW1xjpybJ\ndWGuTYd0HJZB3Ya+SLHDnZmmvsj4t1JRW2A7Yjpp7J4kpOXGNEVqDbG4k/w+duCxVKw31/Xp/9S1\na9cKNd55UB+K6Ynsq9DBySSmg9BfjRoH7ZL9G4olyzKpQfIgZbaTdWCsUepu7EdJevXVVwufVaoT\n9SDWie8I9n3Iv43toMbV1NihOwP2JfcM0MaoaVILDn1GG6O+yH7o3bt3Ls3DnbkXI3RwOmPFsh08\nAJp2y1iyQ4cOzaXprxqyL8Zx5R4FxnWO+bXTxjjvhPyPaXPUf0PvxxD+hWmMMcYk4AnTGGOMScAT\npjHGGJNAk5z5Yr6DXEMPaZhcj2YM1ZhmSVgHaizUJ0Of8R48j7GpZ0+SkMYZO/czlub17MeYDptC\nU309dxYcQ2oW1Ek4PiENM9YW2ja1GdpITIcLQQ2TMTY5pqwDNTDaITXLkA8ly6DOxnZxLNgGfk89\nKeS/Sq2WpPjV7myoJ7JfaGMxf3GpaHP0w+Q96f99+OGH59LcY5Ci3bEvY3F8Gb/26aefzqX5nNCG\nQ1ogbSbmRx07u5bfx3R2qfjO4LPDe2wL/8I0xhhjEvCEaYwxxiTgCdMYY4xJoEmxZKmTVVVVVSw8\ntJ5N/7fYGX/0BaS+GItvmxIPlfEzqfdRK+D6N/UO1oE+XVLaeZWNYTuZn7os81M3CNWTfparV6+u\nWKfmgppETH+gFkTtTyr2B22ZxOIoU/vheIR0FPoXsh3Uh7gngHXgs0HtNhQfk88f2xmLd0vYbo5V\nSK9kvWNnke4KYrbOvkw545bvFT6jfDcxTT2RpMQS5vjQxqjd0W+d31OzZB1Cfre081jsWLaDNsX3\nFN9t1Eylos3RN5Q+rdXV1cG6+RemMcYYk4AnTGOMMSYBT5jGGGNMAhU1zJUrV+bS1PZi8RZDWhL1\nidh5ltRYQufrNYbr2e3bty/k4Ro69Quud1NvpKbJNNsd0oHYLmpeMb/LWOzDmEYnFeNhsg6heKi7\nghdffDGXjvmssp60Q6k4howlSbvh9xxDfk9COhw1SfY39SCWwWeD37MfQs8KNcxYPFrqcDEtnb6A\n1Iak4j4EvkdC743mhv1ALY/pWGzhUB7eo127drk047byPRXTyakvSsVngePJOg0fPjyXZrtjsYZ5\nZqdUfBexDmwXdW8+e7yehJ497jPh+yD17F//wjTGGGMS8IRpjDHGJOAJ0xhjjEmgoobJdXlqR/Qr\nSvFN4no2z79kmYzTyjV56iGE8RelomZJLYBr6tQoqXFS1+G6fuicOhLzE4z5WTJN/SqkeXK8qDdt\nT/zZnQG1H445dThqYPxekurr63Np9ge/J9Q8qLPxnvQNleL6O+2O7aJ+FPNfDGm51Bhpm7R13oM2\nwX7h2PFZkYp2xnvGfD+bgxUrVuTS8+bNy6XZT7GxkoqxYFPjlW4r/4ABA3Lp+fPn59I8L1Mqvh+p\nk3Is2C6OH+2+trY2lw6962i3fP/y3E/WgWXy/Zrif0wWL16cS9Mv036YxhhjzA7gCdMYY4xJwBOm\nMcYYk4AnTGOMMSaBipt+KDpzI0psk09o00hsI0ls8wqds2OHO4c2u3CTz8EHH5xLx4Kts8zu3bvn\n0uwXli/Fg60T9kMsODg3Y4SCELBdrNPu2vTDzQt1dXW5dL9+/XJpBlsO9S03K9AGaEdMc/NL7FAA\n2pAUP+ycZaQ4xzeGG49CQa5jB0TzHrHnkZuIYhuTQp/9IwTM4EYUtpvBNLgRhe8AqWjHHA8+fwxc\n3q1bt1yaNhULPBKqJzdU8dmJbcqkfTBYAgMEhMpgms8S7xF7l7GNtEGpaHN81kKb9EL4F6YxxhiT\ngCdMY4wxJgFPmMYYY0wCFTXM2EHKMR2NzvYhYtocHYKpA8WCs4d0Vl7DdlFzZLtiB06TUD/E2kF4\nD+oVXOdnOtQPbDf7OuZo31xQg+CBsdQjQsEpYlA/4iG11HpCukhjUmyd/Us7ow3wntR6mD+mkUlF\nu4kFDYhpntTpWOeQIzu1OupeseDazUFNTU0uzcDo99xzTy4de/dJ8QOgqbUPGzYsl2ZfU6OmfhjS\nMJ9++ulcmuO1aNGiXJrBFtgvhGMZ0s2fffbZXJoHF1CT5H6DWKACtikUuIDvPwYq6NOnT+GaEP6F\naYwxxiTgCdMYY4xJwBOmMcYYk0BFDZM+OfSPoW7D/KHAy9RVYgcjU0fj2nPs4M+Qdkd9j9oAdZ2Y\nzyT1RR66GtI3YpoX60ioV/AeMS1YKvYd9Qi2Y1cxcODAXJo+ctQb2TYeQCvFA5Xze9oEDwGgjzJt\nJGQztH36ftGnkc8PtT5qWBzz0PPHdlNzDOmejaE+FDs8vUuXLoUy2Df0BQz5sDY39A3k2Jx88sm5\nNIOYP/PMM4UyY9obtVqO7wsILJ3WAAAO3klEQVQvvFAxP8fuhBNOKNSB7+zHH388l6aOzjTvyWdv\nyZIluXTID5MB3qmT0k6beiAACb1b+WzQr5Za7bb2pfgXpjHGGJOAJ0xjjDEmAU+YxhhjTAJN8sOk\nv1vsMNnQOnBMo4yV0blz51x6e3wHqaFQO4rVIRZvk2vyIR2V9eQ6PesQi/vKe1BPDulCjKfIe65c\nuTKXLpVKhTKaA+oN1FWoL1LPDfmjMe4mdRWOKctoqq9nyB+N/ct2UcujHx+1HWo5tMOQHslrqDny\nWaBmye/pt0nNK+RfTL+72IHBuwLaFNtJfZ/9yPxS3Lc3ZCONoS/o9OnTc+ljjjkml54zZ06hDOrc\n3APCZ5rjxf0AS5cuzaXpnxp6z8QOpaaNUZtlP7GOLD8UizhWJp89a5jGGGPMDuAJ0xhjjEnAE6Yx\nxhiTQEUNk/5v9G+hrxL1xZD/IbW7WExU6mwxv6GUGKCsF6+hzx3X5WPnZfL7lDM5uWbOa2KxZ2M+\neCHfJOo2HJuYj2tzcfTRR+fS9Jmitkc9KaSBcYzZX7EYq9SoqBGH/PAI9SNqL/yedkW9idezX0J6\nPvWdkG02JnZO4PacbUmdM+aPuiuInXfKZ4V9H+rH2DmO1I/pw8g6cXwfeeSRXHrw4MGFOtD3M6YP\nU7Pk+5Nt4N6AZcuWFcpkO9hO+mWyr9lP//RP/5RL055CNkc9meeX0ue8urq6UIbkX5jGGGNMEp4w\njTHGmAQ8YRpjjDEJVNQwP/WpT+XSMf+XWBxKKe7jSG2I38fiuh522GG5dEjHoTbLetNHj7oMffZi\ncV9D+gY/i/Ul/U2ps1IXYJ1D/UBNJKab7irYVupJ1B+oN4Z0N/pRUpuhbsLvqdVwzFlH6i5S0W44\n5hzDbt265dLU9pg/5qsrFcecdkK9if5qMX/VmH+wFD9jkz5xuwJqe7///e9z6ZivYCh+MZ8nnttI\nm/zzn/+cS1N/pF1Tq6PfplR8nxLaA+PX0o+Tds7xpr+qVBzPmN80x4I2yP0IbHfo2WM7+bzHzv0s\n41+YxhhjTAKeMI0xxpgEPGEaY4wxCVQU36jTUFOhPlFXV5dLh87j45o6z6GLnYUX0wtjGqhU9Emk\nD07sjM5QfMzGcF0/1CZqQTG/StaR6Vhs2lAdYuddxvTi5qJ9+/a5NDUJ6keLFi3KpUN67VtvvZVL\nUx+i/kfdhPoRdRbqKKEz+6iDEWqUzz//fMU6URuKxSaVin1HW4/5SMb8EWNxmqXi88S+3B2xZNnX\n7Ieqqqpcmu+6kG5Om6JvH+Oyrlq1KpfmO4DPAcc75ANJTZF9S5vk+FJ3pW7K54jPmVR81/H5ZDti\nNkTNk/s5Qs8/x2fx4sW5NM+33Rb+hWmMMcYk4AnTGGOMScATpjHGGJNARUGQa8/UwejPyHX9lPiK\n1BNj51lynZ7XM95m6BzD2JmcMX9TxiWk5sZ1fuohUlFbpd4Ri/EZi7lLbSqk/TJWbMo1uwL2L3U3\najnUMHi9VNRaCMeD+ambUHeh1hPS72NQ/6G/GW2EdsU6U4+Smn7eZUyjjPlhhs4mpb5L26V/6a4g\nFlt07dq1ufSRRx6ZS4eeFepisZiqtBnqjbwn330pNsc68dmqr6/Ppfk+ZZ3o3xjyxY+9y2iDtKGY\nVs/nJDQWfL4/+clP5tJ8h28L/8I0xhhjEvCEaYwxxiTgCdMYY4xJwBOmMcYYk0DFXR0x53gGCWA6\nJL7GNtRQnOXGBW7iYXncABIiFkydm2EoZMfaHTucOATvwTLYl7GgArFABiEozscCGzQX3IgQcwDn\n5omUw5y5cYhpbm6gjXCDRSyguFTcnMANFiyD7eaYxg7zDcF6xZ4nprnRKBZIO2SndCJv6oa35oA2\nF9tUl3K4OstkXzKwOe2B78KYDfL6EBw/bkSKBTLg2HATZmxznVS0Cd6TzzPbzU1ArFPXrl0L9+RG\nIW6wSz1owr8wjTHGmAQ8YRpjjDEJeMI0xhhjEqioYVKPoKZF7YH5Qw77JBaonIcJx0g5xJqBsjt1\n6lSxTjxQmjoptQSuuYegntHUw5t5fUq7CbXX2KHVuwrqINRmYhp0SMtbsWJFLh0LIh4LfE3th+MX\nCoTOMpYsWZJLx7Rb6kV0tk7Rj+hozmeU9eb3MbtjOqSdU3slsSD1zQHryXbyWaGOFtJq+Z5g0AB+\nz77n80ebix2CLhXf2YcddlguzcMvON7sF44NbS506EAsIArLTNmH0hi2O6TlcjwZoIPP1nHHHRe8\nl39hGmOMMQl4wjTGGGMS8IRpjDHGJFBRw4z5GsV0t5AvGtf6eU2qP0wZrodzzT3kC8r1a15DTZJ1\niuk4DIqccngzr6Eux36jvkEfPbY71A8cP7Y7dPj2riAWfJs6CTUM6nRS0e+KvoD0iYtpedQjSeiQ\ncdabeagHMU3NkjZDXY2HB0vxQ6ZjhzfzmaYemeJDGQvQHtLBmhvqZvSZjfkjhuAhALRr2mSHDh0q\npqn1sZ9COiqfe47vwQcfnEtTF+XYdOvWLZfm+LPfpOLh3CyTzx7fQzF74fU87FuSampqcmn2Q8yv\nvYx/YRpjjDEJeMI0xhhjEvCEaYwxxiRQUcPs3LlzLk0dh2vy1OpSfANjflwx30CuPdOviGvyoWu4\nDh/TUWOHYJOQlhs7tJoaCfXEmN8Y9efYwdyhe6b4kzYHHDNqNbQJjhf1SamoWTA2KPuTMVapH7Fv\nQnZGYnliPskxbXd7/J5j8U5j+iLtihpWSAen/suD57nHYFdA/TfmC8h3QMi3NOZPyrE49NBDc2n6\nE9MfnGm2QYq/Fwj9EWP9wjTfvylQs6SNsUzaVEosYvYV9wOE3hkh/AvTGGOMScATpjHGGJOAJ0xj\njDEmgYoaJteCqWny+5gvYApcr2YZ/D7my5ai3XFNPFZvlsl+SPHRou7JdlC/it0zdn0I6lPsB2oL\nuwrqItSCYvptyAeSehH1vpguGoubTF+wkH4V07RicToZi5S+gdQPQ76izNO9e/eKdWC/xe7B60Nj\nEYuZuzv8MNku+kjSt4/tDvnxcfx4DTVLji/LpA8k+/HZZ58t1CEWC5ZaPP10Y7G9WWfG3A3Besb8\nSfnOZ37uTwjZHH1au3Tpkkun7EGQ/AvTGGOMScITpjHGGJOAJ0xjjDEmgYpiXSyWKLUH5k+JC0st\nLua7Se2P69n0hwr5QMY0Rq6Bx85zo9bH60P6RkynCdW7EqF1+8aE2hy7x+6KJRvTXWgj1E1CegTL\niMXAZBn004qdFRqyY/Z3LD4p9SSWGYuxGeqHmEZFnY3pWCxaErJz9jVtN9UnbmcS86ulD2xK7FHq\nZiyT37Pd9BVmbFrGCqbGKUlLly7NpWlzLJP2QJ9Ytpt1YHlS8QxO+jjzfcp+4f4N6qasI7VhqWi3\nfKezr7eFf2EaY4wxCXjCNMYYYxLwhGmMMcYkUFHDpDb0pz/9KX8x1p6pRYRiW1KHYRxJ3pPaAtee\n6aPD9fEQXKfnPekHGDv/MkZIK2QZsdiyzM9+YZt4z5CGGYtX29SzSZsLaj/0byOh72M+w9Q4O3Xq\nlEtTA2GdeH3oXEDaJvOwv3kPajX8ns9bKLYo89COGHMzFt825r8WGouY313sTM7mIBY3+cUXX8yl\nqQWm1Pnwww/PpamD04b4bmSc1z/84Q+59IoVKwr3pPbKsykZW5bt4nPCdrLfeL1U1DVj+1BCz05j\n2G+sw8svv1y4hs8W+5JzQHV1dfDe/oVpjDHGJOAJ0xhjjEnAE6YxxhiTQEUNk/6FsfilKX57XCum\nJhKL40rNkmvqPOeMMSFDNPU8zNj5a9sTS5br8CwjFns2ds+Q7hqL2ZjSjuaAmgb1w9h4hTQQarrU\nA2m7HI+Y310s1mzoM2pWtH3qgzE7C+lHhGVSX4rVkWMRO/8y5B9MXS3mQ7w7YD/R35A2GtPVpaKd\n0seVeydYB2qWHKtQ/GiOF22G78v6+vpCGZXg+Ie0XJZZU1OTS1NrZ7t69uyZS7PO9MsMaffMQxtk\nfFtrmMYYY8wO4AnTGGOMScATpjHGGJOAJ0xjjDEmgYo7bGIHQlNA5oYeblSRipsjYkEE6FhLwZf5\n+X1o48rq1atz6WeeeaZinWIbQmKHDYeCIrPMWBBswvyxdMrGipUrV+bS3AS0q+AGCtadm1u4gScE\nN+3EAubzgFnaEctj4OzQph9ewzHmBjXWiRs41qxZk0tzgw4PtZaKARl4T26GiG364WaYWAANqdj3\nDJadMp47m9hByRxfbsh57bXXCmXGNkGybzmetDn2S9euXXPp0IHvU6dOzaW5YY4HY3NzDG20RYsW\nFcsLbX7KsiyXjgV+iW2gYt9zrEIbjzg+tFsG7NgW/oVpjDHGJOAJ0xhjjEnAE6YxxhiTQEUNk2vN\nTXUwTjm0mPegZhkLIsDyqLOGtAW2g1otob5BDZNaLbWqUGBntpPENMzYwdvUXEIBIdhuaq0hTWRX\nQAfumPZH/SFkM9RRCO0kdmAw7Y46XCgoOR2qqb0ccsghuTTHkHXgmLNfQodcU9+hU3nMjvgsxA69\npsYlFTVo9uWSJUty6e7duxfK2Nmw3dR/aQ8kpPfTBphmcHWOBceTwdv5/LI8Ka69Mhh/LGgI4diF\n9EdqubwmFlSENst+4fXc1yIV39Hsh9SD0f0L0xhjjEnAE6YxxhiTgCdMY4wxJoGKGubcuXNz6UGD\nBuXS9AOiT1dIw6QGEgtkzvzUmmL5Q/ohtTmu89MfkVAboiaacuA09QfWm+v21H1i+nJKQHm2k2X8\n7Gc/y6XHjh1bKKM5ePLJJ3PpmBZEvSmkvcYCVVNnoY8cNSzqjSSkYdLHjfegrcYC8lMv6tChQ8X8\noWt4D9pNLMA79SamQ9peTJOeP39+Ln3aaacVytjZUD9s165dLk2NK0W7I9QHqavRJ5JafuzgCY6/\nVBxPvus4niwjdoA438ehwy74rqMmzWeF9+BzwgMD2KaQHskyqHPOmTMnl/7MZz5TKEPyL0xjjDEm\nCU+YxhhjTAKeMI0xxpgEWmQxBzVjjDHG+BemMcYYk4InTGOMMSYBT5jGGGNMAp4wjTHGmAQ8YRpj\njDEJeMI0xhhjEvh/bIHItqmLRW4AAAAASUVORK5CYII=\n",
             "text/plain": [
               "<Figure size 576x396 with 3 Axes>"
             ]
@@ -948,10 +949,10 @@
       "metadata": {
         "id": "QPyc8as42WTQ",
         "colab_type": "code",
-        "outputId": "b5dfed78-51a9-4e5d-97fa-4e3fadeae075",
+        "outputId": "69ea09ee-8198-42d5-a654-2bd3e339e5b2",
         "colab": {
           "base_uri": "https://localhost:8080/",
-          "height": 90
+          "height": 122
         }
       },
       "cell_type": "code",
@@ -971,28 +972,42 @@
         "  !curl -F \"file=@descriptor.h5\" https://file.io\n",
         "descriptor_model_trip.save_weights('descriptor.h5') "
       ],
-      "execution_count": 0,
+      "execution_count": 19,
       "outputs": [
         {
           "output_type": "stream",
           "text": [
             "Epoch 1/1\n",
-            "1999/2000 [============================>.] - ETA: 0s - loss: 0.2142"
+            "1999/2000 [============================>.] - ETA: 0s - loss: 0.2180"
           ],
           "name": "stdout"
         },
         {
           "output_type": "stream",
           "text": [
-            "100%|██████████| 100000/100000 [00:03<00:00, 26687.44it/s]\n"
+            " 93%|█████████▎| 93058/100000 [00:03<00:00, 31816.45it/s]"
           ],
           "name": "stderr"
         },
         {
           "output_type": "stream",
           "text": [
-            "\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\r2000/2000 [==============================] - 159s 79ms/step - loss: 0.2142 - val_loss: 0.2183\n",
-            "{\"success\":true,\"key\":\"4Yi9cf\",\"link\":\"https://file.io/4Yi9cf\",\"expiry\":\"14 days\"}"
+            "\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\b\r2000/2000 [==============================] - 162s 81ms/step - loss: 0.2180 - val_loss: 0.2352\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "100%|██████████| 100000/100000 [00:03<00:00, 25025.97it/s]\n",
+            "100%|██████████| 10000/10000 [00:00<00:00, 61048.19it/s]\n"
+          ],
+          "name": "stderr"
+        },
+        {
+          "output_type": "stream",
+          "text": [
+            "{\"success\":true,\"key\":\"4TMbf9\",\"link\":\"https://file.io/4TMbf9\",\"expiry\":\"14 days\"}"
           ],
           "name": "stdout"
         }
@@ -1011,21 +1026,35 @@
         "\n",
         "![](https://i.ibb.co/WcDDf3q/Screenshot-from-2019-02-15-11-17-24.png)\n",
         "\n",
-        "This function generates those files by passing it a descriptor model and a denoising model. It performs a first step of denoising the patches, and a second one of computing the descriptor of the denoised patch. If no denoising model is given (variable set to None), the descriptor is computed directly in the noisy patch."
+        "This function generates those files by passing it a descriptor model and a denoising model. It performs a first step of denoising the patches, and a second one of computing the descriptor of the denoised patch. If no denoising model is given (variable set to `None`), the descriptor is computed directly in the noisy patch.\n",
+        "\n",
+        "Similarly to the loading data part, you have the denoise_model variable and `use_clean` variable. If `use_clean` is set to True, the CSV generated will be those of the clean patches, even if a denoising model is given. If set to False, then depends on the variable `denoise_model`. If there is no denoise model (`denoise_model=None`), then it will use the noisy patches. If you give a denoising model, then it will compute the CSV for the denoised patches. This can be useful to explore different scenarios (for example, the Upper Bound can be training the descriptor network with clean patches, and testing with clean patches), however you should always report the score when using noisy patches (depending on the approach you develop, you may want to denoise them or not). The official baseline uses the denoised patches. "
       ]
     },
     {
       "metadata": {
         "id": "kiJb2XDG9bsJ",
         "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        },
+        "outputId": "44209aa0-be20-4c05-8a39-2264b61cb08e"
       },
       "cell_type": "code",
       "source": [
-        "generate_desc_csv(descriptor_model, denoise_model, seqs_test)"
+        "generate_desc_csv(descriptor_model, seqs_test, denoise_model=denoise_model, use_clean=False)"
       ],
-      "execution_count": 0,
-      "outputs": []
+      "execution_count": 20,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "100%|██████████| 40/40 [06:35<00:00, 11.25s/it]\n"
+          ],
+          "name": "stderr"
+        }
+      ]
     },
     {
       "metadata": {
@@ -1049,6 +1078,8 @@
       "source": [
         "Now we will perform the evaluation of three different tasks (Verification, Matching and Evaluation) using the CSV files we generated as input and the `hpatches_eval.py` script. We also print the results using the `hpatches_results.py` script. The scripts will return a score for each of the tasks. The metric used is called mean Average Precision, which it uses the Precision of the model. The Precision is defined, for a given number of retrieved elements, as the ratio of correct retrieved elements / number of retrieved elements. [Link to Wikipedia with Precision explanation](https://en.wikipedia.org/wiki/Precision_and_recall). The definition of the three different tasks is taken from the [HPatches paper](https://arxiv.org/pdf/1704.05939.pdf).\n",
         "\n",
+        "In all of the tasks if you use the optional argument `--more_info` in `hpatches_results.py` you can see extra mAP information. However, the important score is the mAP score reported without this flag.\n",
+        "\n",
         "### Verification\n",
         "\n",
         "Patch verification measures the ability of a descriptor to classify whether two patches are extracted from the same measurement. Now we compute the score of our architecture in this task.\n",
@@ -1060,15 +1091,39 @@
       "metadata": {
         "id": "Awnyv4xTYSFH",
         "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 238
+        },
+        "outputId": "be06d7d6-203a-44ac-9d00-bf10fe2c997e"
       },
       "cell_type": "code",
       "source": [
         "!python ./hpatches-benchmark/hpatches_eval.py --descr-name=custom --descr-dir=/content/keras_triplet_descriptor/out/ --task=verification --delimiter=\";\"\n",
         "!python ./hpatches-benchmark/hpatches_results.py --descr=custom --results-dir=./hpatches-benchmark/results/ --task=verification\n"
       ],
-      "execution_count": 0,
-      "outputs": []
+      "execution_count": 21,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "\n",
+            ">> Running HPatch evaluation for \u001b[34mcustom\u001b[0m\n",
+            ">> Please wait, loading the descriptor files...\n",
+            ">> Descriptor files loaded.\n",
+            ">> Evaluating \u001b[32mverification\u001b[0m task\n",
+            "Processing verification task 1/3 : 100% 1000000/1000000 [01:32<00:00, 10865.68it/s]\n",
+            "Processing verification task 2/3 : 100% 1000000/1000000 [01:30<00:00, 10992.03it/s]\n",
+            "Processing verification task 3/3 : 100% 1000000/1000000 [01:31<00:00, 10900.89it/s]\n",
+            ">> \u001b[32mVerification\u001b[0m task finished in 284 secs  \n",
+            "\u001b[32mVerification\u001b[0m task results:\n",
+            "Mean Average Precision is 0.714930\n",
+            "\n",
+            "\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "metadata": {
@@ -1085,15 +1140,39 @@
       "metadata": {
         "id": "EUqpwi87ckJv",
         "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 238
+        },
+        "outputId": "bae8823a-85dd-4c72-d162-bc294b20acb8"
       },
       "cell_type": "code",
       "source": [
         "!python ./hpatches-benchmark/hpatches_eval.py --descr-name=custom --descr-dir=/content/keras_triplet_descriptor/out/ --task=matching --delimiter=\";\"\n",
         "!python ./hpatches-benchmark/hpatches_results.py --descr=custom --results-dir=./hpatches-benchmark/results/ --task=matching\n"
       ],
-      "execution_count": 0,
-      "outputs": []
+      "execution_count": 22,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "\n",
+            ">> Running HPatch evaluation for \u001b[34mcustom\u001b[0m\n",
+            ">> Please wait, loading the descriptor files...\n",
+            ">> Descriptor files loaded.\n",
+            ">> Evaluating \u001b[32mmatching\u001b[0m task\n",
+            "100% 40/40 [02:07<00:00,  4.29s/it]\n",
+            ">> \u001b[32mMatching\u001b[0m task finished in 127 secs  \n",
+            "\u001b[32mMatching\u001b[0m task results:\n",
+            "Mean Average Precision is 0.104292\n",
+            "\n",
+            "\n",
+            "\n",
+            "\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "metadata": {
@@ -1110,15 +1189,40 @@
       "metadata": {
         "id": "ZNmKIat1cn_M",
         "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 275
+        },
+        "outputId": "7e970d03-b631-4ab9-9a84-452031fc6ded"
       },
       "cell_type": "code",
       "source": [
         "!python ./hpatches-benchmark/hpatches_eval.py --descr-name=custom --descr-dir=/content/keras_triplet_descriptor/out/ --task=retrieval --delimiter=\";\"\n",
-        "!python ./hpatches-benchmark/hpatches_results.py --descr=custom --results-dir=./hpatches-benchmark/results/ --task=retrieval\n"
+        "!python ./hpatches-benchmark/hpatches_results.py --descr=custom --results-dir=./hpatches-benchmark/results/ --task=retrieval"
       ],
-      "execution_count": 0,
-      "outputs": []
+      "execution_count": 23,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "\n",
+            ">> Running HPatch evaluation for \u001b[34mcustom\u001b[0m\n",
+            ">> Please wait, loading the descriptor files...\n",
+            ">> Descriptor files loaded.\n",
+            ">> Evaluating \u001b[32mretrieval\u001b[0m task\n",
+            ">> Please wait, computing distance matrix...\n",
+            "tcmalloc: large alloc 1600004096 bytes == 0x56234abbe000 @  0x7fd73548d1e7 0x7fd72b08ecf1 0x7fd72b0f13a2 0x7fd72b0f30de 0x7fd72b18a0e8 0x562323519fe5 0x56232350fd0a 0x5623235175fe 0x562323517232 0x56232350fd0a 0x562323517c38 0x56232350fd0a 0x56232350f629 0x56232354061f 0x56232353b322 0x56232353a67d 0x5623234e91ab 0x7fd73508ab97 0x5623234e8a2a\n",
+            ">> Distance matrix done.\n",
+            "Processing retrieval task: 100% 10000/10000 [03:57<00:00, 42.23it/s]\n",
+            ">> \u001b[32mRetrieval\u001b[0m task finished in 276 secs  \n",
+            "\u001b[32mRetrieval\u001b[0m task results:\n",
+            "Mean Average Precision is 0.358950\n",
+            "\n",
+            "\n"
+          ],
+          "name": "stdout"
+        }
+      ]
     },
     {
       "metadata": {
@@ -1209,14 +1313,38 @@
       "metadata": {
         "id": "UwrqWr_c7pAi",
         "colab_type": "code",
-        "colab": {}
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 51
+        },
+        "outputId": "005994a0-bb3c-4c8d-dc93-91fdd94a4e98"
       },
       "cell_type": "code",
       "source": [
         "save_file_to_drive('descriptors_save.zip', 'descriptors.zip')"
       ],
-      "execution_count": 0,
-      "outputs": []
+      "execution_count": 26,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "File ID: 1dHq0eDqoLMMmr6YOexZOU6cLwhFJYgH8\n"
+          ],
+          "name": "stdout"
+        },
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "{u'id': u'1dHq0eDqoLMMmr6YOexZOU6cLwhFJYgH8'}"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 26
+        }
+      ]
     }
   ]
 }

--- a/hpatches-benchmark/hpatches_eval.py
+++ b/hpatches-benchmark/hpatches_eval.py
@@ -16,7 +16,6 @@ Options:
   --dist=<>         Distance name. Valid are {L1,L2}. [default: L2]
   --delimiter=<>    Delimiter used in the csv files. [default: ,]
   --pcapl=<>        Compute results for pca-power law descr. [default: no]
-
 For more visit: https://github.com/hpatches/
 """
 from utils.hpatch import *
@@ -56,12 +55,8 @@ if __name__ == '__main__':
 
     for t in opts['--task']:
         res_path = os.path.join(results_dir, descr_name+"_"+t+"_"+splt['name']+".p")
-        if os.path.exists(res_path):
-            print("Results for the %s, %s task, split %s, already cached!" %\
-                  (descr_name,t,splt['name']))
-        else:
-            res = methods[t](descr,splt)
-            dill.dump(res, open(res_path, "wb"))
+        res = methods[t](descr,splt)
+        dill.dump(res, open(res_path, "wb"))
 
     # do the PCA/power-law evaluation if wanted
     if opts['--pcapl']!='no':

--- a/hpatches-benchmark/hpatches_results.py
+++ b/hpatches-benchmark/hpatches_results.py
@@ -3,7 +3,7 @@
 Usage:
   hpatches_results.py (-h | --help)
   hpatches_results.py --version
-  hpatches_results.py --descr-name=<>... --task=<>... [--results-dir=<>] [--split=<>] [--pcapl=<>]
+  hpatches_results.py --descr-name=<>... --task=<>... [--results-dir=<>] [--split=<>] [--pcapl=<>] [--more_info]
 
 Options:
   -h --help         Show this screen.
@@ -13,7 +13,7 @@ Options:
   --task=<>         Task name. Valid tasks are {verification,matching,retrieval}.
   --split=<>        Split name. Valid are {a,b,c,full,illum,view}. [default: a]
   --pcapl=<>        Show results for pca-power law descr. [default: no]
-
+  --more_info       Outputs partial scores, not only final mAP
 For more visit: https://github.com/hpatches/
 """
 from utils.tasks import tskdir
@@ -26,16 +26,14 @@ from utils.docopt import docopt
 if __name__ == '__main__':
     opts = docopt(__doc__, version='HPatches 1.0')
     descrs = opts['--descr-name']
-
     with open(os.path.join(tskdir, "splits", "splits.json")) as f:
         splits = json.load(f)
     splt = splits[opts['--split']]
-
     for t in opts['--task']:
         print("%s task results:" % (green(t.capitalize())))
         for desc in descrs:
-            results_methods[t](desc,splt)
+            results_methods[t](desc,splt,opts['--more_info'])
             if opts['--pcapl']!='no':
-                results_methods[t](desc+'_pcapl',splt)
+                results_methods[t](desc+'_pcapl',splt,opts['--more_info'])
             print
         print

--- a/hpatches-benchmark/utils/results.py
+++ b/hpatches-benchmark/utils/results.py
@@ -7,22 +7,24 @@ import numpy as np
 
 ft = {'e':'Easy','h':'Hard','t':'Tough'}
 
-def results_verification(desc,splt):
+def results_verification(desc,splt,more_info=False):
     v = {'imbalanced':'ap'}
     res = dill.load(open(os.path.join("results", desc+"_verification_"+splt['name']+".p"), "rb"))
     for r in v:
-        # print("%s - %s variant (%s) " % (blue(desc.upper()),r.capitalize(),v[r]))
+        if more_info:
+            print("%s - %s variant (%s) " % (blue(desc.upper()),r.capitalize(),v[r]))
         heads = ["Noise","Inter","Intra"]
         results = []
         for t in ['e','h','t']:
             results.append([ft[t], res[t]['inter'][r][v[r]],res[t]['intra'][r][v[r]]])
-        # print(tb(results,headers=heads))
+        if more_info:
+            print(tb(results,headers=heads))
     mAP = np.asarray(list(map(lambda x: x[1:], results))).mean()
     print('Mean Average Precision is {:f}'.format(mAP))
 
 
 
-def results_matching(desc,splt):
+def results_matching(desc,splt,more_info=False):
     res = dill.load(open(os.path.join("results", desc+"_matching_"+splt['name']+".p"), "rb"))
     mAP = {'e':0,'h':0,'t':0}
     k_mAP = 0
@@ -33,18 +35,21 @@ def results_matching(desc,splt):
                 mAP[t] += res[seq][t][idx]['ap']
                 k_mAP+=1
     k_mAP = k_mAP / 3.0
-    # print("%s - mAP " % (blue(desc.upper())))
+    if more_info:
+        print("%s - mAP " % (blue(desc.upper())))
 
     results = [mAP['e']/k_mAP,mAP['h']/k_mAP,mAP['t']/k_mAP]
     results.append(sum(results)/float(len(results)))
-    # print(tb([results],headers=heads))
+    if more_info:
+        print(tb([results],headers=heads))
     print('Mean Average Precision is {:f}'.format(results[-1]))
     print("\n")
 
 
-def results_retrieval(desc,splt):
+def results_retrieval(desc,splt,more_info=False):
     res = dill.load(open(os.path.join("results", desc+"_retrieval_"+splt['name']+".p"), "rb"))
-    # print("%s - mAP 10K queries " % (blue(desc.upper())))
+    if more_info:
+        print("%s - mAP 10K queries " % (blue(desc.upper())))
     n_q= float(len(res.keys()))
     heads = ['']
     mAP = dict.fromkeys(['e','h','t'])
@@ -68,7 +73,8 @@ def results_retrieval(desc,splt):
 
     res = np.array(results)[:,1:].astype(np.float32)
     results.append(['mean']+list(np.mean(res,axis=0)))
-    # print(tb(results,headers=heads))
+    if more_info:
+        print(tb(results,headers=heads))
     mAP = np.asarray(results[-1][1:]).mean()
     print('Mean Average Precision is {:f}'.format(mAP))
 

--- a/read_data.py
+++ b/read_data.py
@@ -77,7 +77,7 @@ class DenoiseHPatches(keras.utils.Sequence):
 class hpatches_sequence_folder:
     """Class for loading an HPatches sequence from a sequence folder"""
     itr = tps
-    def __init__(self, base, noise = 1):
+    def __init__(self, base, noise=1):
         name = base.split('/')
         self.name = name[-1]
         self.base = base

--- a/utils.py
+++ b/utils.py
@@ -54,7 +54,7 @@ def plot_denoise(denoise_model):
     plt.gca().set_yticks([])
     plt.show()
 
-def generate_desc_csv(descriptor_model, denoise_model, seqs_test, curr_desc_name = 'custom'):
+def generate_desc_csv(descriptor_model, seqs_test, denoise_model=None, use_clean=False, curr_desc_name='custom'):
     """Plots a noisy patch, denoised patch and clean patch.
     Args:
         descriptor_model: keras model used to generate descriptor
@@ -64,25 +64,28 @@ def generate_desc_csv(descriptor_model, denoise_model, seqs_test, curr_desc_name
     """
     w = 32
     bs = 128
-    output_dir  = './out'
+    output_dir = './out'
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
-    
+    if use_clean:
+        noisy_patches = 0
+        denoise_model = None
+    else:
+        noisy_patches = 1
     for seq_path in tqdm(seqs_test):
-        seq = hpatches_sequence_folder(seq_path, noise = 1)
+        seq = hpatches_sequence_folder(seq_path, noise=noisy_patches)
 
         path = os.path.join(output_dir, os.path.join(curr_desc_name, seq.name))
         if not os.path.exists(path):
             os.makedirs(path)
         for tp in tps:
             n_patches = 0
-            for i,patch in enumerate(getattr(seq, tp)):
-                n_patches+=1
+            for i, patch in enumerate(getattr(seq, tp)):
+                n_patches += 1
 
             patches_for_net = np.zeros((n_patches, 32, 32, 1))
-            uuu = 0
-            for i,patch in enumerate(getattr(seq, tp)):            
-                patches_for_net[i,:,:, 0] = cv2.resize(patch[0:w,0:w],(32,32))
+            for i, patch in enumerate(getattr(seq, tp)):
+                patches_for_net[i, :, :, 0] = cv2.resize(patch[0:w, 0:w], (32,32))
             ###
             outs = []
             
@@ -108,5 +111,5 @@ def generate_desc_csv(descriptor_model, denoise_model, seqs_test, curr_desc_name
 
             res_desc = np.concatenate(outs)
             res_desc = np.reshape(res_desc, (n_patches, -1))
-            out = np.reshape(res_desc, (n_patches,-1))
+            out = np.reshape(res_desc, (n_patches, -1))
             np.savetxt(os.path.join(path,tp+'.csv'), out, delimiter=';', fmt='%10.5f')   # X is an array


### PR DESCRIPTION
Added the option to generate CSV files for clean/original HPatches data too. Also, added flag --more_info in the results to print extra mAP information for the different tasks.